### PR TITLE
Update link for list of changes?

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@ a fetched resource has been delivered without unexpected manipulation.</p>
 
 <section id="sotd">
   <p>A list of changes to this document may be found at
-<a href="https://github.com/w3c/webappsec">https://github.com/w3c/webappsec</a>.</p>
+<a href="https://github.com/w3c/webappsec-subresource-integrity/issues">https://github.com/w3c/webappsec-subresource-integrity/issues</a>.</p>
 </section>
 
 <section class="informative">


### PR DESCRIPTION
Seems like the "list of changes" link should now be https://github.com/w3c/webappsec-subresource-integrity/issues