### PR TITLE
Redefine WSP as White_Space characters from the HTML 5 spec.

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,12 +168,12 @@ substitute malicious content.</p>
   <p>This example can be communicated to a user agent by adding the hash to a
 <code>script</code> element, like so:</p>
 
-  <pre><code>&lt;script src="https://example.com/example-framework.js"
+  <pre class="example"><code>&lt;script src="https://example.com/example-framework.js"
         integrity="sha384-Li9vy3DqF8tnTXuiaAJuML3ky+er10rcgNR/VqsVpcw+ThHmYcwiB1pbOxEbzJr7"
         crossorigin="anonymous"&gt;&lt;/script&gt;
 </code></pre>
 
-  <p class="example">Scripts, of course, are not the only response type which would benefit
+  <p>Scripts, of course, are not the only response type which would benefit
 from integrity validation. The scheme specified here also applies to <code>link</code>
 and future versions of the specification are likely to expand this coverage.</p>
 
@@ -288,9 +288,13 @@ NIST in <a href="http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf
     <p>The Augmented Backus-Naur Form (ABNF) notation used in this document is
 specified in RFC5234. [[!ABNF]]</p>
 
-    <p>The following core rules are included by reference, as defined in
-<a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">Appendix B.1</a> of [[!ABNF]]: <code><dfn>WSP</dfn></code> (white space)
-and <code><dfn>VCHAR</dfn></code> (printing characters).</p>
+    <p>The following core rules are included by reference, as defined in <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">Appendix
+B.1</a> of [[!ABNF]] defines <code><dfn>VCHAR</dfn></code> (printing
+characters).</p>
+
+    <p><code><dfn>WSP</dfn></code> (white space) characters are defined in Section
+<a href="http://www.w3.org/TR/html5/infrastructure.html#space-character">2.4.1 Common parser idioms</a> of the HTML 5 specification as
+<code>White_Space characters.</code></p>
 
   </section>
 
@@ -320,10 +324,8 @@ pieces of information:</p>
     <p>The hash function and digest MUST be provided in order to validate a
 response’s integrity.</p>
 
-    <div class="note">
-      <p>At the moment, no options are defined. However, future versions of
+    <p class="note">At the moment, no options are defined. However, future versions of
 the spec may define options, such as MIME types [[!MIMETYPE]].</p>
-    </div>
 
     <p>This metadata MUST be encoded in the same format as the <code>hash-source</code> (without the single quotes)
 in <a href="http://www.w3.org/TR/CSP2/#source-list-syntax">section 4.2 of the Content Security Policy Level 2 specification</a>.</p>
@@ -343,7 +345,6 @@ result of the following command line:</p>
 
       <pre><code>echo -n "alert('Hello, world.');" | openssl dgst -sha384 -binary | openssl enc -base64 -A
 </code></pre>
-
     </div>
 
   </section>
@@ -364,13 +365,13 @@ resource in order to provide agility in the face of future cryptographic discove
 For example, the resource described in the previous section may be described
 by either of the following hash expressions:</p>
 
-      <pre><code>sha384-dOTZf16X8p34q2/kYyEFm0jh89uTjikhnzjeLeF0FHsEaYKb1A1cv+Lyv4Hk8vHd
+      <pre class="example"><code>sha384-dOTZf16X8p34q2/kYyEFm0jh89uTjikhnzjeLeF0FHsEaYKb1A1cv+Lyv4Hk8vHd
 sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzCinRE7Af1ofPrw==
 </code></pre>
 
       <p>Authors may choose to specify both, for example:</p>
 
-      <pre><code>&lt;script src="hello_world.js"
+      <pre class="example"><code>&lt;script src="hello_world.js"
    integrity="sha384-dOTZf16X8p34q2/kYyEFm0jh89uTjikhnzjeLeF0FHsEaYKb1A1cv+Lyv4Hk8vHd
               sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzCinRE7Af1ofPrw=="
    crossorigin="anonymous"&gt;&lt;/script&gt;
@@ -405,12 +406,10 @@ collision-resistant.  For example, <code>getPrioritizedHashFunction('sha256',
 'sha512')</code> would return <code>'sha512'</code> and <code>getPrioritizedHashFunction('sha256',
 'sha256')</code> would return the empty string.</p>
 
-      <div class="note">
-        <p>The <dfn>getPrioritizedHashFunction</dfn> is an internal 
+      <p class="note">The <dfn>getPrioritizedHashFunction</dfn> is an internal 
 implementation detail. It is not an API that implementors 
 provide to web applications. It is used in this document 
 only to simplify the algorithm description.</p>
-      </div>
 
     </section>
     <!-- /Framework::Cryptographic hash functions::Priority -->
@@ -576,7 +575,7 @@ metadata from <var>parsedMetadata</var></a>.</li>
       <p>This algorithm allows the user agent to accept multiple, valid strong hash
 functions. For example, a developer might write a <code>script</code> element such as:</p>
 
-      <pre><code>&lt;script src="https://example.com/example-framework.js"
+      <pre class="example"><code>&lt;script src="https://example.com/example-framework.js"
         integrity="sha384-Li9vy3DqF8tnTXuiaAJuML3ky+er10rcgNR/VqsVpcw+ThHmYcwiB1pbOxEbzJr7
                    sha384-+/M6kredJcxdsqkczBUjMLvqyHb1K/JThDXWsBVxMEeZHEaMKEOEct339VItX1zB"
         crossorigin="anonymous"&gt;&lt;/script&gt;
@@ -586,7 +585,7 @@ functions. For example, a developer might write a <code>script</code> element su
 of which matches the first SHA384 hash value and the other matches the second
 SHA384 hash value.</p>
 
-      <p class="example note">User agents may allow users to modify the result of this algorithm via user
+      <p class="note">User agents may allow users to modify the result of this algorithm via user
 preferences, bookmarklets, third-party additions to the user agent, and other
 such mechanisms. For example, redirects generated by an extension like
 <a href="https://www.eff.org/https-everywhere">HTTPS Everywhere</a> could load and execute

--- a/spec.markdown
+++ b/spec.markdown
@@ -164,11 +164,16 @@ NIST in ["FIPS PUB 180-4: Secure Hash Standard (SHS)"][shs].
 The Augmented Backus-Naur Form (ABNF) notation used in this document is
 specified in RFC5234. [[!ABNF]]
 
-The following core rules are included by reference, as defined in
-[Appendix B.1][abnf-b1] of [[!ABNF]]: <code><dfn>WSP</dfn></code> (white space)
-and <code><dfn>VCHAR</dfn></code> (printing characters).
+The following core rules are included by reference, as defined in [Appendix
+B.1][abnf-b1] of [[!ABNF]] defines <code><dfn>VCHAR</dfn></code> (printing
+characters).
+
+<code><dfn>WSP</dfn></code> (white space) characters are defined in Section
+[2.4.1 Common parser idioms][space-chars] of the HTML 5 specification as
+<code>White_Space characters.</code>
 
 [abnf-b1]: https://tools.ietf.org/html/rfc5234#appendix-B.1
+[space-chars]: http://www.w3.org/TR/html5/infrastructure.html#space-character
 </section>
 
 </section>


### PR DESCRIPTION
To resolve the whitespace problem in #1, I redefined WSP in Section 2.2 as White_Space characters from the HTML 5 spec. I believe this should automatically resolve the problem in section 3.5. Please take a look, @devd @fmarier @mozfreddyb.