### PR TITLE
Change hash value in Example 5 & 6 (fixes #52)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -320,7 +320,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
 
   <div class="example">
   <pre>
-      sha384-dOTZf16X8p34q2/kYyEFm0jh89uTjikhnzjeLeF0FHsEaYKb1A1cv+Lyv4Hk8vHd
+      sha384-H8BRh8j48O9oYatfu5AZzq6A9RINhZO5H16dQZngK7T62em8MUt1FLm52t+eX6xO
       sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzCinRE7Af1ofPrw==
   </pre>
   </div>
@@ -330,7 +330,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   <div class="example">
   <pre>
       &lt;script src="hello_world.js"
-         integrity="sha384-dOTZf16X8p34q2/kYyEFm0jh89uTjikhnzjeLeF0FHsEaYKb1A1cv+Lyv4Hk8vHd
+         integrity="sha384-H8BRh8j48O9oYatfu5AZzq6A9RINhZO5H16dQZngK7T62em8MUt1FLm52t+eX6xO
                     sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzCinRE7Af1ofPrw=="
          crossorigin="anonymous"&gt;&lt;/script&gt;
   </pre>


### PR DESCRIPTION
As mentioned in #52, the hash for sha512 matches one pre-image and the sha384 is for another. This makes the example confusing, as it is about two hashes for the same script.
The example in itself is non-normative so this is more or less a cosmetic change. I assume almost nobody (kudos to @manger) would compute those themselves.

Hence, I'd just patch the editor's draft and not add this to the REC.