### PR TITLE
Update index.bs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -597,7 +597,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   the list of content attributes for the `link` and `script` elements.
 
   A corresponding `integrity` IDL attribute which <a>reflects</a> the
-  value each element's `integrity` content attribute is added to the
+  value of each element's `integrity` content attribute is added to the
   `HTMLLinkElement` and `HTMLScriptElement` interfaces.
 
   Note: A future revision of this specification is likely to include integrity support


### PR DESCRIPTION
Fixes a grammatical error in the definition of the `integrity` attribute.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/mfoltzgoogle/webappsec-subresource-integrity/patch-1.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webappsec-subresource-integrity/f6b778b...mfoltzgoogle:4ea3079.html)