### PR TITLE
Fix formatting

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -276,8 +276,8 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   href="http://www.w3.org/TR/CSP2/#source-list-syntax">section 4.2 of the Content
   Security Policy Level 2 specification</a>.
 
-  For example, given a script resource containing only the string `alert(\'Hello,
-  world.\');`, an author might choose <a>SHA-384</a> as a hash function.
+  For example, given a script resource containing only the string `alert('Hello,
+  world.');`, an author might choose <a>SHA-384</a> as a hash function.
   `H8BRh8j48O9oYatfu5AZzq6A9RINhZO5H16dQZngK7T62em8MUt1FLm52t+eX6xO` is the <a
   lt="base64 encoding">base64 encoded</a> digest that results. This can be encoded
   as follows:

--- a/spec_v1.markdown
+++ b/spec_v1.markdown
@@ -192,7 +192,7 @@ the spec may define options, such as MIME types [[!MIMETYPE]].
 This metadata MUST be encoded in the same format as the `hash-source` (without the single quotes)
 in [section 4.2 of the Content Security Policy Level 2 specification][csp2-section42].
 
-For example, given a script resource containing only the string `alert(\'Hello, world.\');`,
+For example, given a script resource containing only the string `alert('Hello, world.');`,
 an author might choose [SHA-384][sha2] as a hash function.
 `H8BRh8j48O9oYatfu5AZzq6A9RINhZO5H16dQZngK7T62em8MUt1FLm52t+eX6xO` is the base64-encoded
 digest that results. This can be encoded as follows:


### PR DESCRIPTION
Quotes must not be escaped in inline \`code\` elements, it causes the
backslashes to appear verbatim in the final page.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tom93/webappsec-subresource-integrity/pull/81.html" title="Last updated on May 23, 2019, 1:05 AM UTC (0316991)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/81/3aadfcc...tom93:0316991.html" title="Last updated on May 23, 2019, 1:05 AM UTC (0316991)">Diff</a>