### PR TITLE
Revert `require-sri-for`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -765,17 +765,6 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   to load the document. A successful load would confirm that the attacker
   has correctly guessed the username.
 
-
-  <section>
-    <h2 id="iana-considerations">IANA Considerations</h2>
-
-    The Content Security Policy Directive registry should be updated with the
-    following directives and references [[!RFC7762]]:
-
-    :   <a>`require-sri-for`</a>
-    ::  This document (see [[#opt-in-require-sri-for]])
-  </section>
-
   <!-- ####################################################################### -->
 
   # Acknowledgements # {#acknowledgements}

--- a/index.bs
+++ b/index.bs
@@ -421,27 +421,6 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
 
   3.  Return "Allowed".
 
-  <div class="example">
-    A page with the following Content Security Policy:
-
-    <pre>
-      Content-Security-Policy: <a>require-sri-for</a> script style
-    </pre>
-
-    is equivalent to Content Security Policy delivered through `<meta>`
-    element:
-
-    <pre>
-      &lt;meta http-equiv="Content-Security-Policy"
-            content="<a>require-sri-for</a> script style"&gt;
-    </pre>
-
-
-    and requires <a>integrity metadata</a> be present in `script`
-    and `link` HTML elements that contain `src` attribute.
-  </div>
-
-
   ## Response verification algorithms ## {#response-verification-algorithms}
 
   ### Apply |algorithm| to |response| ### {#apply-algorithm-to-response}

--- a/index.bs
+++ b/index.bs
@@ -36,16 +36,6 @@ spec: ABNF; urlPrefix: https://tools.ietf.org/html/rfc5234
     text: VCHAR; url: appendix-B.1
     text: WSP; url: appendix-B.1
 
-spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
-  type: dfn
-    text: Content Security Policy; urlPrefix: #
-    text: policy; url: policy
-    text: directive; url: directives
-    text: value; for: directive; url: directive-value
-    text: pre-request check; url: directive-pre-request-check
-    text: create a violation object for global; url: create-violation-for-global
-    text: report violation; url: report-violation
-    text: disposition; for: policy
 
 spec: Fetch; urlPrefix: https://fetch.spec.whatwg.org
   type: dfn
@@ -56,25 +46,14 @@ spec: Fetch; urlPrefix: https://fetch.spec.whatwg.org
 
 spec: HTML5; urlPrefix: http://www.w3.org/TR/html5/
   type: dfn
-    text: global object; url: global-object
     urlPrefix: document-metadata.html
       text: obtain a resource; url: concept-link-obtain
     urlPrefix: infrastructure.html
       text: CORS settings attribute; url: #cors-settings-attributes
       text: reflect; url: #reflect
-      text: split a string on spaces; url: #split-a-string-on-spaces
     urlPrefix: scripting-1.html
       text: prepare a script; url: #prepare-a-script
       text: splitting tokens on spaces; url: split-a-string-on-spaces
-      text: ASCII case-insensitive match; url: ascii-case-insensitive
-  type: interface
-    urlPrefix: dom.html
-      text: Document
-
-spec: RFC7230; urlPrefix: https://tools.ietf.org/html/rfc7230
-  type: grammar
-    text: RWS; url: section-3.2.3
-    text: token; url: section-3.2.6
 
 spec: RFC7234; urlPrefix: https://tools.ietf.org/html/rfc7234
   type: dfn
@@ -366,62 +345,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   provide to web applications. It is used in this document
   only to simplify the algorithm description.
 
-  ## Request verification algorithms ## {#request-verification-algorithms}
-
-  ### Opting-in  ### {#opt-in-require-sri-for}
-
-  Authors may opt a {{Document}} to require SRI metadata be present for 
-  some resource types via a <dfn export>require-sri-for</dfn> <a>Content
-  Security Policy</a> directive defined by the following ABNF grammar:
-
-  <pre dfn-type="grammar" link-type="grammar">
-      directive-name  = "require-sri-for"
-      directive-value = <a grammar>token</a> *( <a>RWS</a> <a>token</a> )
-  </pre>
-
-  The following list contains the set of <dfn noexport>known tokens</dfn>:
-
-    * `script` requires SRI for scripts
-    * `style` requires SRI for style sheets
-
-
-  ### Parsing `require-sri-for` ### {#parse-require-sri-for}
-
-  Given a string (|token list|), this algorithm returns a list of resource
-  types which will require integrity checks:
-
-  1.  Let the set of |protected resource types| that require SRI be the empty set.
-
-  2.  For each |token| in the result of <a lt="split a string on spaces">
-      splitting |token list| on spaces</a>, if token matches the grammar
-      for <a>require-sri-for</a> and is a <a>ASCII case-insensitive match</a>
-      for any of the <a>known token</a>s, add |token| to |protected resource types|.
-      Otherwise, ignore the token.
-
-  3.  Return the set of |protected resource types|.
-
-  ### Apply |algorithm| to |request| ### {#apply-algorithm-to-request}
-
-  This directive’s <a>pre-request check</a> is as follows:
-
-  Given a <a>request</a> (|request|) and a <a>policy</a> (|policy|):
-
-  1.  Let |protected resource types| be the result of executing
-      [[#parse-require-sri-for]] on this <a>directive</a>'s <a for="directive">value</a>.
-
-  2.  If |request|'s <a>destination</a> is a <a>ASCII case-insensitive match</a> for at least
-      one token in |protected resource types|, and |request|'s integrity metadata
-      is the empty string, return "Blocked".
-
-      Note: This logic means that request with matched <a>destination</a> and missing <a>integrity metadata</a>
-      will be blocked even if it is not currently possible to set it's <a>integrity metadata</a>.
-      Such requests are originated by, for example, <code>importScripts()</code>, CSS' <code>@import</code>,
-      or `script`/`style` elements without crossorigin content attribute.
-
-
-  3.  Return "Allowed".
-
-  ## Response verification algorithms ## {#response-verification-algorithms}
+  ## Response verification algorithms ## {#verification-algorithms}
 
   ### Apply |algorithm| to |response| ### {#apply-algorithm-to-response}
 


### PR DESCRIPTION
I really liked the feature. :cry: 

However, we ended up unshipping in Gecko and IIRC @mikewest considered removing from Blink, so I'm making an attempt at removing `require-sri-for`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mozfreddyb/webappsec-subresource-integrity/pull/82.html" title="Last updated on Jul 2, 2019, 1:14 PM UTC (9931d3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/82/6edd03a...mozfreddyb:9931d3c.html" title="Last updated on Jul 2, 2019, 1:14 PM UTC (9931d3c)">Diff</a>