### PR TITLE
typo: content-encoding

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -351,7 +351,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   1.  Let |result| be the result of [[#apply-algorithm-to-response]]
       to the <a>representation data</a> without any content-codings
       applied, except when the user agent intends to consume the content with
-      content-encodings applied. In the latter case, let |result| be
+      content-codings applied. In the latter case, let |result| be
       the result of applying |algorithm| to the <a>representation data</a>.
   2.  Let |encodedResult| be result of <a>base64 encoding</a> |result|.
   3.  Return |encodedResult|.


### PR DESCRIPTION
## This PR

fix terminology Content-Encoding is an header, not a content-coding


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ioggstream/webappsec-subresource-integrity/pull/94.html" title="Last updated on Jan 15, 2021, 10:59 AM UTC (0ecf245)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/94/094d447...ioggstream:0ecf245.html" title="Last updated on Jan 15, 2021, 10:59 AM UTC (0ecf245)">Diff</a>