### PR TITLE
chore: Remove quotes in URL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -60,7 +60,7 @@ spec: RFC7234; urlPrefix: https://tools.ietf.org/html/rfc7234
     text: Cache-Control; url: section-5.2
     text: no-transform; url: section-5.2.1.6
 
-spec: SECURE-CONTEXTS; urlPrefix: "http://www.w3.org/TR/powerful-features/"
+spec: SECURE-CONTEXTS; urlPrefix: http://www.w3.org/TR/powerful-features/
   type: dfn
     text: Secure Context; urlPrefix: #
 

--- a/index.html
+++ b/index.html
@@ -1323,7 +1323,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 89ebb6ab, updated Fri Oct 9 15:32:07 2020 -0700" name="generator">
   <link href="http://www.w3.org/TR/SRI/" rel="canonical">
-  <meta content="62b40e8dbb45cb78203e6dd6a1c65c80a849e435" name="document-revision">
+  <meta content="434c58b02889cfb60b85e4cdd05a963b1db21240" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -2214,13 +2214,13 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
    <h2 class="heading settled" data-level="5" id="security-considerations"><span class="secno">5. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
    <p><em> This section is not normative.</em></p>
    <h3 class="heading settled" data-level="5.1" id="non-secure-contexts"><span class="secno">5.1. </span><span class="content">Non-secure contexts remain non-secure</span><a class="self-link" href="#non-secure-contexts"></a></h3>
-   <p><a data-link-type="dfn" href="#integrity-metadata" id="ref-for-integrity-metadata⑦">Integrity metadata</a> delivered by a context that is not a <a data-link-type="dfn" href="&quot;http://www.w3.org/TR/powerful-features/&quot;#secure-context" id="ref-for-secure-context">Secure
+   <p><a data-link-type="dfn" href="#integrity-metadata" id="ref-for-integrity-metadata⑦">Integrity metadata</a> delivered by a context that is not a <a data-link-type="dfn" href="http://www.w3.org/TR/powerful-features/#secure-context" id="ref-for-secure-context">Secure
   Context</a> such as an HTTP page, only protects an origin against a compromise
   of the server where an external resources is hosted. Network attackers can alter
   the digest in-flight (or remove it entirely, or do absolutely anything else to
   the document), just as they could alter the response the hash is meant to
   validate.  Thus, it is recommended that authors deliver integrity metadata only
-  to a <a data-link-type="dfn" href="&quot;http://www.w3.org/TR/powerful-features/&quot;#secure-context" id="ref-for-secure-context①">Secure Context</a>. See also <a href="http://www.w3.org/2001/tag/doc/web-https ">Securing the Web</a>.</p>
+  to a <a data-link-type="dfn" href="http://www.w3.org/TR/powerful-features/#secure-context" id="ref-for-secure-context①">Secure Context</a>. See also <a href="http://www.w3.org/2001/tag/doc/web-https ">Securing the Web</a>.</p>
    <h3 class="heading settled" data-level="5.2" id="hash-collision-attacks"><span class="secno">5.2. </span><span class="content">Hash collision attacks</span><a class="self-link" href="#hash-collision-attacks"></a></h3>
    <p>Digests are only as strong as the hash function used to generate them. It is
   recommended that user agents refuse to support known-weak hashing functions and
@@ -2369,7 +2369,7 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="&quot;http://www.w3.org/TR/powerful-features/&quot;#secure-context">"http://www.w3.org/TR/powerful-features/"#secure-context</a><b>Referenced in:</b>
+   <a href="http://www.w3.org/TR/powerful-features/#secure-context">http://www.w3.org/TR/powerful-features/#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">5.1. Non-secure contexts remain non-secure</a> <a href="#ref-for-secure-context①">(2)</a>
    </ul>


### PR DESCRIPTION
Bikeshed produces invalid link element


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nschonni/webappsec-subresource-integrity/pull/95.html" title="Last updated on Feb 22, 2021, 2:56 PM UTC (e46d479)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/95/abe7f92...nschonni:e46d479.html" title="Last updated on Feb 22, 2021, 2:56 PM UTC (e46d479)">Diff</a>