### PR TITLE
Reference Fetch spec rather than CORS spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -361,7 +361,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   In order to mitigate an attacker's ability to read data cross-origin by
   brute-forcing values via integrity checks, responses are only eligible for such
   checks if they are same-origin or are the result of explicit access granted to
-  the loading origin via Cross Origin Resource Sharing [[!CORS]].
+  the loading origin via Cross Origin Resource Sharing [[!Fetch]].
 
   Note: As noted in 
   <a href="https://tools.ietf.org/html/rfc6454#section-4">RFC6454, section 4</a>,


### PR DESCRIPTION
Fixes https://github.com/w3c/webappsec-subresource-integrity/issues/41


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/pull/96.html" title="Last updated on Feb 18, 2021, 2:05 AM UTC (3e90510)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/96/550b2d9...3e90510.html" title="Last updated on Feb 18, 2021, 2:05 AM UTC (3e90510)">Diff</a>