### PR TITLE
Remove text redundant with HTML

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -438,11 +438,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   A variety of HTML elements result in requests for resources that are to be
   embedded into the document, or executed in its context. To support integrity
   metadata for some of these elements, a new `integrity` attribute is added to
-  the list of content attributes for the `link` and `script` elements.
-
-  A corresponding `integrity` IDL attribute which <a>reflects</a> the
-  value of each element's `integrity` content attribute is added to the
-  `HTMLLinkElement` and `HTMLScriptElement` interfaces.
+  the list of content attributes for the `link` and `script` elements. [[!HTML]]
 
   Note: A future revision of this specification is likely to include integrity support
   for all possible subresources, i.e., `a`, `audio`, `embed`, `iframe`, `img`,
@@ -463,8 +459,6 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
       <dfn>hash-expression</dfn>    = <a>hash-algo</a> "-" <a>base64-value</a>
   </pre>
 
-  The `integrity` IDL attribute must <a>reflect</a> the `integrity` content attribute.
-
   `option-expression`s are associated on a per `hash-expression` basis and are
   applied only to the `hash-expression` that immediately precedes it.
 
@@ -476,31 +470,6 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   will define a more specific syntax for options, so it is defined here as broadly
   as possible.
 
-  ## Element interface extensions ## {#interface-extensions}
-
-  ### HTMLLinkElement ### {#HTMLLinkElement}
-
-  <pre class="idl">
-    partial interface HTMLLinkElement {
-      attribute DOMString integrity;
-    };
-  </pre>
-
-  #### Attributes #### {#HTMLLinkElement-Attributes}
-  <b>integrity</b> of type `DOMString`: The value of this element's integrity
-  attribute.
-
-  ### HTMLScriptElement ### {#HTMLScriptElement}
-  <pre class="idl">
-    partial interface HTMLScriptElement {
-      attribute DOMString integrity;
-    };
-  </pre>
-
-  #### Attributes #### {#HTMLScriptElement-Attributes}
-  <b>integrity</b> of type `DOMString`: The value of this element's integrity
-  attribute.
-
   ## Handling integrity violations ## {#handling-integrity-violations}
 
   The user agent will refuse to render or execute responses that fail an integrity
@@ -511,28 +480,6 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   from a CDN, perhaps from a secondary, trusted, but slower source) can catch this
   `error` event and provide an appropriate handler to replace the
   failed resource with a different one.
-
-  ## Elements ## {#elements}
-
-  ### The `link` element for stylesheets ### {#link-element-for-stylesheets}
-
-  Whenever a user agent attempts to <a>obtain a resource</a> pointed to by a
-  `link` element that has a `rel` attribute with the keyword of `stylesheet`,
-  modify step 4 to read:
-
-  Do a potentially CORS-enabled fetch of the resulting absolute URL, with the
-  mode being the current state of the element's crossorigin content attribute,
-  the origin being the origin of the link element's Document, the default origin
-  behavior set to taint, and the <a>integrity metadata</a> of the request set to
-  the value of the element's `integrity` attribute.
-
-  ### The `script` element ### {#script-element}
-
-  Replace step 14.1 of HTML5's <a>prepare a script</a> algorithm with:
-
-  1.  Let |src| be the value of the element's `src` attribute and
-      the request's associated <a>integrity metadata</a> be the value of the
-      element's `integrity` attribute.
 
   <!-- ####################################################################### -->
 

--- a/index.html
+++ b/index.html
@@ -1323,7 +1323,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 89ebb6ab, updated Fri Oct 9 15:32:07 2020 -0700" name="generator">
   <link href="http://www.w3.org/TR/SRI/" rel="canonical">
-  <meta content="afa3d6af9a8a8a7550d6a5ccf49741786f894843" name="document-revision">
+  <meta content="62b40e8dbb45cb78203e6dd6a1c65c80a849e435" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1626,69 +1626,6 @@ a.self-link::before            { content: "¶"; }
 .heading > a.self-link::before { content: "§"; }
 dfn > a.self-link::before      { content: "#"; }
 </style>
-<style>/* style-syntax-highlighting */
-
-            pre.idl.highlight {
-                background: var(--borderedblock-bg, var(--def-bg));
-            }
-            
-code.highlight { padding: .1em; border-radius: .3em; }
-pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-
-.highlight:not(.idl) { background: rgba(0, 0, 0, .03); }
-c-[a] { color: #990055 } /* Keyword.Declaration */
-c-[b] { color: #990055 } /* Keyword.Type */
-c-[c] { color: #708090 } /* Comment */
-c-[d] { color: #708090 } /* Comment.Multiline */
-c-[e] { color: #0077aa } /* Name.Attribute */
-c-[f] { color: #669900 } /* Name.Tag */
-c-[g] { color: #222222 } /* Name.Variable */
-c-[k] { color: #990055 } /* Keyword */
-c-[l] { color: #000000 } /* Literal */
-c-[m] { color: #000000 } /* Literal.Number */
-c-[n] { color: #0077aa } /* Name */
-c-[o] { color: #999999 } /* Operator */
-c-[p] { color: #999999 } /* Punctuation */
-c-[s] { color: #a67f59 } /* Literal.String */
-c-[t] { color: #a67f59 } /* Literal.String.Single */
-c-[u] { color: #a67f59 } /* Literal.String.Double */
-c-[cp] { color: #708090 } /* Comment.Preproc */
-c-[c1] { color: #708090 } /* Comment.Single */
-c-[cs] { color: #708090 } /* Comment.Special */
-c-[kc] { color: #990055 } /* Keyword.Constant */
-c-[kn] { color: #990055 } /* Keyword.Namespace */
-c-[kp] { color: #990055 } /* Keyword.Pseudo */
-c-[kr] { color: #990055 } /* Keyword.Reserved */
-c-[ld] { color: #000000 } /* Literal.Date */
-c-[nc] { color: #0077aa } /* Name.Class */
-c-[no] { color: #0077aa } /* Name.Constant */
-c-[nd] { color: #0077aa } /* Name.Decorator */
-c-[ni] { color: #0077aa } /* Name.Entity */
-c-[ne] { color: #0077aa } /* Name.Exception */
-c-[nf] { color: #0077aa } /* Name.Function */
-c-[nl] { color: #0077aa } /* Name.Label */
-c-[nn] { color: #0077aa } /* Name.Namespace */
-c-[py] { color: #0077aa } /* Name.Property */
-c-[ow] { color: #999999 } /* Operator.Word */
-c-[mb] { color: #000000 } /* Literal.Number.Bin */
-c-[mf] { color: #000000 } /* Literal.Number.Float */
-c-[mh] { color: #000000 } /* Literal.Number.Hex */
-c-[mi] { color: #000000 } /* Literal.Number.Integer */
-c-[mo] { color: #000000 } /* Literal.Number.Oct */
-c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
-c-[sc] { color: #a67f59 } /* Literal.String.Char */
-c-[sd] { color: #a67f59 } /* Literal.String.Doc */
-c-[se] { color: #a67f59 } /* Literal.String.Escape */
-c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
-c-[si] { color: #a67f59 } /* Literal.String.Interpol */
-c-[sx] { color: #a67f59 } /* Literal.String.Other */
-c-[sr] { color: #a67f59 } /* Literal.String.Regex */
-c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
-c-[vc] { color: #0077aa } /* Name.Variable.Class */
-c-[vg] { color: #0077aa } /* Name.Variable.Global */
-c-[vi] { color: #0077aa } /* Name.Variable.Instance */
-c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
-</style>
 <style>/* style-darkmode */
 
 @media (prefers-color-scheme: dark) {
@@ -1808,70 +1745,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
         --dfnpanel-bg: #222;
         --dfnpanel-text: var(--text);
     }
-}
-@media (prefers-color-scheme: dark) {
-    .highlight:not(.idl) { background: rgba(255, 255, 255, .05); }
-
-    c-[a] { color: #d33682 } /* Keyword.Declaration */
-    c-[b] { color: #d33682 } /* Keyword.Type */
-    c-[c] { color: #2aa198 } /* Comment */
-    c-[d] { color: #2aa198 } /* Comment.Multiline */
-    c-[e] { color: #268bd2 } /* Name.Attribute */
-    c-[f] { color: #b58900 } /* Name.Tag */
-    c-[g] { color: #cb4b16 } /* Name.Variable */
-    c-[k] { color: #d33682 } /* Keyword */
-    c-[l] { color: #657b83 } /* Literal */
-    c-[m] { color: #657b83 } /* Literal.Number */
-    c-[n] { color: #268bd2 } /* Name */
-    c-[o] { color: #657b83 } /* Operator */
-    c-[p] { color: #657b83 } /* Punctuation */
-    c-[s] { color: #6c71c4 } /* Literal.String */
-    c-[t] { color: #6c71c4 } /* Literal.String.Single */
-    c-[u] { color: #6c71c4 } /* Literal.String.Double */
-    c-[ch] { color: #2aa198 } /* Comment.Hashbang */
-    c-[cp] { color: #2aa198 } /* Comment.Preproc */
-    c-[cpf] { color: #2aa198 } /* Comment.PreprocFile */
-    c-[c1] { color: #2aa198 } /* Comment.Single */
-    c-[cs] { color: #2aa198 } /* Comment.Special */
-    c-[kc] { color: #d33682 } /* Keyword.Constant */
-    c-[kn] { color: #d33682 } /* Keyword.Namespace */
-    c-[kp] { color: #d33682 } /* Keyword.Pseudo */
-    c-[kr] { color: #d33682 } /* Keyword.Reserved */
-    c-[ld] { color: #657b83 } /* Literal.Date */
-    c-[nc] { color: #268bd2 } /* Name.Class */
-    c-[no] { color: #268bd2 } /* Name.Constant */
-    c-[nd] { color: #268bd2 } /* Name.Decorator */
-    c-[ni] { color: #268bd2 } /* Name.Entity */
-    c-[ne] { color: #268bd2 } /* Name.Exception */
-    c-[nf] { color: #268bd2 } /* Name.Function */
-    c-[nl] { color: #268bd2 } /* Name.Label */
-    c-[nn] { color: #268bd2 } /* Name.Namespace */
-    c-[py] { color: #268bd2 } /* Name.Property */
-    c-[ow] { color: #657b83 } /* Operator.Word */
-    c-[mb] { color: #657b83 } /* Literal.Number.Bin */
-    c-[mf] { color: #657b83 } /* Literal.Number.Float */
-    c-[mh] { color: #657b83 } /* Literal.Number.Hex */
-    c-[mi] { color: #657b83 } /* Literal.Number.Integer */
-    c-[mo] { color: #657b83 } /* Literal.Number.Oct */
-    c-[sa] { color: #6c71c4 } /* Literal.String.Affix */
-    c-[sb] { color: #6c71c4 } /* Literal.String.Backtick */
-    c-[sc] { color: #6c71c4 } /* Literal.String.Char */
-    c-[dl] { color: #6c71c4 } /* Literal.String.Delimiter */
-    c-[sd] { color: #6c71c4 } /* Literal.String.Doc */
-    c-[se] { color: #6c71c4 } /* Literal.String.Escape */
-    c-[sh] { color: #6c71c4 } /* Literal.String.Heredoc */
-    c-[si] { color: #6c71c4 } /* Literal.String.Interpol */
-    c-[sx] { color: #6c71c4 } /* Literal.String.Other */
-    c-[sr] { color: #6c71c4 } /* Literal.String.Regex */
-    c-[ss] { color: #6c71c4 } /* Literal.String.Symbol */
-    c-[fm] { color: #268bd2 } /* Name.Function.Magic */
-    c-[vc] { color: #cb4b16 } /* Name.Variable.Class */
-    c-[vg] { color: #cb4b16 } /* Name.Variable.Global */
-    c-[vi] { color: #cb4b16 } /* Name.Variable.Instance */
-    c-[vm] { color: #cb4b16 } /* Name.Variable.Magic */
-    c-[il] { color: #657b83 } /* Literal.Number.Integer.Long */
-}
-</style>
+}</style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
@@ -1974,27 +1848,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
        </ol>
       <li><a href="#verification-of-html-document-subresources"><span class="secno">3.4</span> <span class="content">Verification of HTML document subresources</span></a>
       <li><a href="#the-integrity-attribute"><span class="secno">3.5</span> <span class="content">The <code>integrity</code> attribute</span></a>
-      <li>
-       <a href="#interface-extensions"><span class="secno">3.6</span> <span class="content">Element interface extensions</span></a>
-       <ol class="toc">
-        <li>
-         <a href="#HTMLLinkElement"><span class="secno">3.6.1</span> <span class="content">HTMLLinkElement</span></a>
-         <ol class="toc">
-          <li><a href="#HTMLLinkElement-Attributes"><span class="secno">3.6.1.1</span> <span class="content">Attributes</span></a>
-         </ol>
-        <li>
-         <a href="#HTMLScriptElement"><span class="secno">3.6.2</span> <span class="content">HTMLScriptElement</span></a>
-         <ol class="toc">
-          <li><a href="#HTMLScriptElement-Attributes"><span class="secno">3.6.2.1</span> <span class="content">Attributes</span></a>
-         </ol>
-       </ol>
-      <li><a href="#handling-integrity-violations"><span class="secno">3.7</span> <span class="content">Handling integrity violations</span></a>
-      <li>
-       <a href="#elements"><span class="secno">3.8</span> <span class="content">Elements</span></a>
-       <ol class="toc">
-        <li><a href="#link-element-for-stylesheets"><span class="secno">3.8.1</span> <span class="content">The <code>link</code> element for stylesheets</span></a>
-        <li><a href="#script-element"><span class="secno">3.8.2</span> <span class="content">The <code>script</code> element</span></a>
-       </ol>
+      <li><a href="#handling-integrity-violations"><span class="secno">3.6</span> <span class="content">Handling integrity violations</span></a>
      </ol>
     <li><a href="#proxies"><span class="secno">4</span> <span class="content">Proxies</span></a>
     <li>
@@ -2023,7 +1877,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
       <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
      </ol>
-    <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
    </ol>
   </nav>
   <main>
@@ -2318,9 +2171,7 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
    <p>A variety of HTML elements result in requests for resources that are to be
   embedded into the document, or executed in its context. To support integrity
   metadata for some of these elements, a new <code>integrity</code> attribute is added to
-  the list of content attributes for the <code>link</code> and <code>script</code> elements.</p>
-   <p>A corresponding <code>integrity</code> IDL attribute which <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#reflect" id="ref-for-reflect">reflects</a> the
-  value of each element’s <code>integrity</code> content attribute is added to the <code>HTMLLinkElement</code> and <code>HTMLScriptElement</code> interfaces.</p>
+  the list of content attributes for the <code>link</code> and <code>script</code> elements. <a data-link-type="biblio" href="#biblio-html">[HTML]</a></p>
    <p class="note" role="note"><span>Note:</span> A future revision of this specification is likely to include integrity support
   for all possible subresources, i.e., <code>a</code>, <code>audio</code>, <code>embed</code>, <code>iframe</code>, <code>img</code>, <code>link</code>, <code>object</code>, <code>script</code>, <code>source</code>, <code>track</code>, and <code>video</code> elements.</p>
    <h3 class="heading settled" data-level="3.5" id="the-integrity-attribute"><span class="secno">3.5. </span><span class="content">The <code>integrity</code> attribute</span><a class="self-link" href="#the-integrity-attribute"></a></h3>
@@ -2334,7 +2185,6 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-base64-value">base64-value</dfn>       = &lt;base64-value production from [Content Security Policy Level 2, section 4.2]>
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-hash-expression">hash-expression</dfn>    = <a data-link-type="grammar" href="#grammardef-hash-algo" id="ref-for-grammardef-hash-algo①">hash-algo</a> "-" <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value">base64-value</a>
 </pre>
-   <p>The <code>integrity</code> IDL attribute must <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#reflect" id="ref-for-reflect①">reflect</a> the <code>integrity</code> content attribute.</p>
    <p><code>option-expression</code>s are associated on a per <code>hash-expression</code> basis and are
   applied only to the <code>hash-expression</code> that immediately precedes it.</p>
    <p>In order for user agents to remain fully forwards compatible with future
@@ -2343,52 +2193,18 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
   no options have been defined. It is likely that a future version of the spec
   will define a more specific syntax for options, so it is defined here as broadly
   as possible.</p>
-   <h3 class="heading settled" data-level="3.6" id="interface-extensions"><span class="secno">3.6. </span><span class="content">Element interface extensions</span><a class="self-link" href="#interface-extensions"></a></h3>
-   <h4 class="heading settled" data-level="3.6.1" id="HTMLLinkElement"><span class="secno">3.6.1. </span><span class="content">HTMLLinkElement</span><a class="self-link" href="#HTMLLinkElement"></a></h4>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement" id="ref-for-htmllinkelement"><c- g>HTMLLinkElement</c-></a> {
-  <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLLinkElement" data-dfn-type="attribute" data-export data-type="DOMString" id="dom-htmllinkelement-integrity"><code><c- g>integrity</c-></code><a class="self-link" href="#dom-htmllinkelement-integrity"></a></dfn>;
-};
-</pre>
-   <h5 class="heading settled" data-level="3.6.1.1" id="HTMLLinkElement-Attributes"><span class="secno">3.6.1.1. </span><span class="content">Attributes</span><a class="self-link" href="#HTMLLinkElement-Attributes"></a></h5>
-    <b>integrity</b> of type <code>DOMString</code>: The value of this element’s integrity
-  attribute. 
-   <h4 class="heading settled" data-level="3.6.2" id="HTMLScriptElement"><span class="secno">3.6.2. </span><span class="content">HTMLScriptElement</span><a class="self-link" href="#HTMLScriptElement"></a></h4>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement" id="ref-for-htmlscriptelement"><c- g>HTMLScriptElement</c-></a> {
-  <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLScriptElement" data-dfn-type="attribute" data-export data-type="DOMString" id="dom-htmlscriptelement-integrity"><code><c- g>integrity</c-></code><a class="self-link" href="#dom-htmlscriptelement-integrity"></a></dfn>;
-};
-</pre>
-   <h5 class="heading settled" data-level="3.6.2.1" id="HTMLScriptElement-Attributes"><span class="secno">3.6.2.1. </span><span class="content">Attributes</span><a class="self-link" href="#HTMLScriptElement-Attributes"></a></h5>
-    <b>integrity</b> of type <code>DOMString</code>: The value of this element’s integrity
-  attribute. 
-   <h3 class="heading settled" data-level="3.7" id="handling-integrity-violations"><span class="secno">3.7. </span><span class="content">Handling integrity violations</span><a class="self-link" href="#handling-integrity-violations"></a></h3>
+   <h3 class="heading settled" data-level="3.6" id="handling-integrity-violations"><span class="secno">3.6. </span><span class="content">Handling integrity violations</span><a class="self-link" href="#handling-integrity-violations"></a></h3>
    <p>The user agent will refuse to render or execute responses that fail an integrity
   check, instead returning a network error as defined in Fetch <a data-link-type="biblio" href="#biblio-fetch">[Fetch]</a>.</p>
    <p class="note" role="note"><span>Note:</span> On a failed integrity check, an <code>error</code> event is fired. Developers
   wishing to provide a canonical fallback resource (e.g., a resource not served
   from a CDN, perhaps from a secondary, trusted, but slower source) can catch this <code>error</code> event and provide an appropriate handler to replace the
   failed resource with a different one.</p>
-   <h3 class="heading settled" data-level="3.8" id="elements"><span class="secno">3.8. </span><span class="content">Elements</span><a class="self-link" href="#elements"></a></h3>
-   <h4 class="heading settled" data-level="3.8.1" id="link-element-for-stylesheets"><span class="secno">3.8.1. </span><span class="content">The <code>link</code> element for stylesheets</span><a class="self-link" href="#link-element-for-stylesheets"></a></h4>
-   <p>Whenever a user agent attempts to <a data-link-type="dfn" href="http://www.w3.org/TR/html5/document-metadata.html#concept-link-obtain" id="ref-for-concept-link-obtain">obtain a resource</a> pointed to by a <code>link</code> element that has a <code>rel</code> attribute with the keyword of <code>stylesheet</code>,
-  modify step 4 to read:</p>
-   <p>Do a potentially CORS-enabled fetch of the resulting absolute URL, with the
-  mode being the current state of the element’s crossorigin content attribute,
-  the origin being the origin of the link element’s Document, the default origin
-  behavior set to taint, and the <a data-link-type="dfn" href="#integrity-metadata" id="ref-for-integrity-metadata⑥">integrity metadata</a> of the request set to
-  the value of the element’s <code>integrity</code> attribute.</p>
-   <h4 class="heading settled" data-level="3.8.2" id="script-element"><span class="secno">3.8.2. </span><span class="content">The <code>script</code> element</span><a class="self-link" href="#script-element"></a></h4>
-   <p>Replace step 14.1 of HTML5’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/scripting-1.html#prepare-a-script" id="ref-for-prepare-a-script">prepare a script</a> algorithm with:</p>
-   <ol>
-    <li data-md>
-     <p>Let <var>src</var> be the value of the element’s <code>src</code> attribute and
-  the request’s associated <a data-link-type="dfn" href="#integrity-metadata" id="ref-for-integrity-metadata⑦">integrity metadata</a> be the value of the
-  element’s <code>integrity</code> attribute.</p>
-   </ol>
    <h2 class="heading settled" data-level="4" id="proxies"><span class="secno">4. </span><span class="content">Proxies</span><a class="self-link" href="#proxies"></a></h2>
    <p>Optimizing proxies and other intermediate servers which modify the
   responses MUST ensure that the digest associated
   with those responses stays in sync with the new content. One option
-  is to ensure that the <a data-link-type="dfn" href="#integrity-metadata" id="ref-for-integrity-metadata⑧">integrity metadata</a> associated with
+  is to ensure that the <a data-link-type="dfn" href="#integrity-metadata" id="ref-for-integrity-metadata⑥">integrity metadata</a> associated with
   resources is updated. Another
   would be simply to deliver only the canonical version of resources
   for which a page author has requested integrity verification.</p>
@@ -2398,7 +2214,7 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
    <h2 class="heading settled" data-level="5" id="security-considerations"><span class="secno">5. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
    <p><em> This section is not normative.</em></p>
    <h3 class="heading settled" data-level="5.1" id="non-secure-contexts"><span class="secno">5.1. </span><span class="content">Non-secure contexts remain non-secure</span><a class="self-link" href="#non-secure-contexts"></a></h3>
-   <p><a data-link-type="dfn" href="#integrity-metadata" id="ref-for-integrity-metadata⑨">Integrity metadata</a> delivered by a context that is not a <a data-link-type="dfn" href="&quot;http://www.w3.org/TR/powerful-features/&quot;#secure-context" id="ref-for-secure-context">Secure
+   <p><a data-link-type="dfn" href="#integrity-metadata" id="ref-for-integrity-metadata⑦">Integrity metadata</a> delivered by a context that is not a <a data-link-type="dfn" href="&quot;http://www.w3.org/TR/powerful-features/&quot;#secure-context" id="ref-for-secure-context">Secure
   Context</a> such as an HTTP page, only protects an origin against a compromise
   of the server where an external resources is hosted. Network attackers can alter
   the digest in-flight (or remove it entirely, or do absolutely anything else to
@@ -2486,12 +2302,6 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
    <li><a href="#grammardef-hash-algo">hash-algo</a><span>, in §3.5</span>
    <li><a href="#grammardef-hash-expression">hash-expression</a><span>, in §3.5</span>
    <li><a href="#grammardef-hash-with-options">hash-with-options</a><span>, in §3.5</span>
-   <li>
-    integrity
-    <ul>
-     <li><a href="#dom-htmllinkelement-integrity">attribute for HTMLLinkElement</a><span>, in §3.6.1</span>
-     <li><a href="#dom-htmlscriptelement-integrity">attribute for HTMLScriptElement</a><span>, in §3.6.2</span>
-    </ul>
    <li><a href="#integrity-metadata">integrity metadata</a><span>, in §3.1</span>
    <li><a href="#grammardef-integrity-metadata">integrity-metadata</a><span>, in §3.5</span>
    <li><a href="#grammardef-option-expression">option-expression</a><span>, in §3.5</span>
@@ -2516,18 +2326,6 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
     <li><a href="#ref-for-concept-request">3.1. Integrity metadata</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmllinkelement">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement">https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-htmllinkelement">3.6.1. HTMLLinkElement</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlscriptelement">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement">https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-htmlscriptelement">3.6.2. HTMLScriptElement</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-origin">
    <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">https://html.spec.whatwg.org/multipage/origin.html#concept-origin</a><b>Referenced in:</b>
    <ul>
@@ -2544,25 +2342,6 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
    <a href="http://www.w3.org/TR/html5/infrastructure.html#cors-settings-attributes">http://www.w3.org/TR/html5/infrastructure.html#cors-settings-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-settings-attributes">5.3. Cross-origin data leakage</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-link-obtain">
-   <a href="http://www.w3.org/TR/html5/document-metadata.html#concept-link-obtain">http://www.w3.org/TR/html5/document-metadata.html#concept-link-obtain</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-link-obtain">3.8.1. The link element for stylesheets</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-prepare-a-script">
-   <a href="http://www.w3.org/TR/html5/scripting-1.html#prepare-a-script">http://www.w3.org/TR/html5/scripting-1.html#prepare-a-script</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-prepare-a-script">3.8.2. The script element</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-reflect">
-   <a href="http://www.w3.org/TR/html5/infrastructure.html#reflect">http://www.w3.org/TR/html5/infrastructure.html#reflect</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-reflect">3.4. Verification of HTML document subresources</a>
-    <li><a href="#ref-for-reflect①">3.5. The integrity attribute</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-iteration-continue">
@@ -2631,13 +2410,6 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
     <li><a href="#termref-for-">3.3.4. Do bytes match metadataList?</a> <a href="#termref-for-">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-idl-DOMString">3.6.1. HTMLLinkElement</a>
-    <li><a href="#ref-for-idl-DOMString①">3.6.2. HTMLScriptElement</a>
-   </ul>
-  </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
@@ -2654,8 +2426,6 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-htmllinkelement">HTMLLinkElement</span>
-     <li><span class="dfn-paneled" id="term-for-htmlscriptelement">HTMLScriptElement</span>
      <li><span class="dfn-paneled" id="term-for-concept-origin">origin</span>
      <li><span class="dfn-paneled" id="term-for-same-origin">same origin</span>
     </ul>
@@ -2663,9 +2433,6 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
     <a data-link-type="biblio">[HTML5]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-cors-settings-attributes">cors settings attribute</span>
-     <li><span class="dfn-paneled" id="term-for-concept-link-obtain">obtain a resource</span>
-     <li><span class="dfn-paneled" id="term-for-prepare-a-script">prepare a script</span>
-     <li><span class="dfn-paneled" id="term-for-reflect">reflect</span>
     </ul>
    <li>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
@@ -2691,11 +2458,6 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
      <li><span class="dfn-paneled" id="term-for-①">sha-256</span>
      <li><span class="dfn-paneled" id="term-for-②">sha-384</span>
      <li><span class="dfn-paneled" id="term-for-③">sha-512</span>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
-    <ul>
-     <li><span class="dfn-paneled" id="term-for-idl-DOMString">DOMString</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -2723,8 +2485,6 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
    <dd>Mike West; Yan Zhu. <a href="https://w3c.github.io/webappsec-secure-contexts/">Secure Contexts</a>. WD. URL: <a href="https://w3c.github.io/webappsec-secure-contexts/">https://w3c.github.io/webappsec-secure-contexts/</a>
    <dt id="biblio-sha2">[SHA2]
    <dd><a href="http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf">FIPS PUB 180-4, Secure Hash Standard</a>. URL: <a href="http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf">http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf</a>
-   <dt id="biblio-webidl">[WebIDL]
-   <dd>Boris Zbarsky. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -2737,16 +2497,6 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
    <dt id="biblio-tls">[TLS]
    <dd>E. Rescorla. <a href="https://tools.ietf.org/html/rfc8446">The Transport Layer Security (TLS) Protocol Version 1.3</a>. August 2018. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc8446">https://tools.ietf.org/html/rfc8446</a>
   </dl>
-  <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement"><c- g>HTMLLinkElement</c-></a> {
-  <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a data-type="DOMString" href="#dom-htmllinkelement-integrity"><code><c- g>integrity</c-></code></a>;
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement"><c- g>HTMLScriptElement</c-></a> {
-  <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a data-type="DOMString" href="#dom-htmlscriptelement-integrity"><code><c- g>integrity</c-></code></a>;
-};
-
-</pre>
   <aside class="dfn-panel" data-for="digest">
    <b><a href="#digest">#digest</a></b><b>Referenced in:</b>
    <ul>
@@ -2767,10 +2517,8 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
     <li><a href="#ref-for-integrity-metadata③">3.2. Cryptographic hash functions</a>
     <li><a href="#ref-for-integrity-metadata④">3.2.1. Agility</a>
     <li><a href="#ref-for-integrity-metadata⑤">3.5. The integrity attribute</a>
-    <li><a href="#ref-for-integrity-metadata⑥">3.8.1. The link element for stylesheets</a>
-    <li><a href="#ref-for-integrity-metadata⑦">3.8.2. The script element</a>
-    <li><a href="#ref-for-integrity-metadata⑧">4. Proxies</a>
-    <li><a href="#ref-for-integrity-metadata⑨">5.1. Non-secure contexts remain non-secure</a>
+    <li><a href="#ref-for-integrity-metadata⑥">4. Proxies</a>
+    <li><a href="#ref-for-integrity-metadata⑦">5.1. Non-secure contexts remain non-secure</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="getprioritizedhashfunction">


### PR DESCRIPTION
This is already tackled by "Verification of HTML document subresources" and HTML Standard (which it now references).

Closes #92.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/pull/99.html" title="Last updated on Feb 22, 2021, 2:48 PM UTC (cc7c669)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/99/62b40e8...cc7c669.html" title="Last updated on Feb 22, 2021, 2:48 PM UTC (cc7c669)">Diff</a>