### PR TITLE
Edit 3.3.2 Parse metadata in more detail

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -349,38 +349,33 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
 
   ### Parse |metadata| ### {#parse-metadata}
 
-  This algorithm accepts a string, and returns either `no metadata`, or a set of
-  valid hash expressions whose hash functions are understood by
-  the user agent.
+  This algorithm accepts a string, and returns a set of hash expressions whose
+  hash functions are understood by the user agent.
 
   1.  Let |result| be the empty set.
-  2.  Let |empty| be equal to `true`.
-  3.  For each |item| returned by <a lt="strictly split">splitting |metadata|
-      on spaces</a>:
-      1.  Set |empty| to `false`.
-      2.  Let |option-expression| be the empty string.
-      3.  Let |tokenlist| be the result of <a lt="strictly split">splitting
-          |item| on U+003F (?)</a>.
-      4.  Let |hash-expression| be the |tokenlist|[0].
-      5.  If |tokenlist|[1] exists, let |option-expression| be the
-          |tokenlist|[1].
-      6.  Let |base64-value| be the empty string.
-      7.  Let |tokenlist| be the result of <a lt="strictly split">splitting
-          |hash-expression| on U+002D (-)</a>.
-      8.  Let |algorithm| be the |tokenlist|[0].
-      9.  If |tokenlist|[1] exists, set |base64-value| be the |tokenlist|[1].
-      10.  If |algorithm| is not a hash function recognized by the user agent,
+  2.  For each |item| returned by <a lt="strictly split">splitting</a>
+      |metadata| on spaces:
+      1.  Let |hash-with-opt-token-list| be the result of
+          <a lt="strictly split">splitting</a> |item| on U+003F (?).
+      2.  Let |hash-expression| be the |hash-with-opt-token-list|[0].
+      3.  Let |base64-value| be the empty string.
+      4.  Let |hash-expr-token-list| be the result of
+          <a lt="strictly split">splitting</a> |hash-expression| on U+002D (-).
+      5.  Let |algorithm| be the |hash-expr-token-list|[0].
+      6.  If |hash-expr-token-list|[1] <a for=list>exists</a>, set
+          |base64-value| be the |hash-expr-token-list|[1].
+      7.  If |algorithm| is not a hash function recognized by the user agent,
            [=continue=] the next |item|.
-      11.  Let |metadata| be a map with its keys initialized as follows:
-           : "`alg`"
-           :: |algorithm|
-           : "`val`"
-           :: |base64-value|
-           : "`opt`"
-           :: |option-expression|
-      12. Append |metadata| to |result|.
-  4.  Return `no metadata` if |empty| is `true`, otherwise return
-      |result|.
+      8. Let |metadata| be the ordered map  «["alg" → |algorithm|,
+         "val" → |base64-value|]».
+
+         Note: Since no `options` are not defined(see the
+         [[#integrity-metadata-description]]), corresponding entry is not set in
+         |metadata|. If `options` are defined in a future version of the spec,
+         |hash-with-opt-token-list|[1] can be utilized as `options`.
+
+      9. <a for=list>Append</a> |metadata| to |result|.
+  3.  Return |result|.
 
   ### Get the strongest metadata from |set| ### {#get-the-strongest-metadata}
 
@@ -405,11 +400,10 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
 
   1.  Let |parsedMetadata| be the result of
       <a href="#parse-metadata">parsing |metadataList|</a>.
-  2.  If |parsedMetadata| is `no metadata`, return `true`.
-  3.  If |parsedMetadata| is the empty set, return `true`.
-  4.  Let |metadata| be the result of <a href="#get-the-strongest-metadata">
+  2.  If |parsedMetadata| is the empty set, return `true`.
+  3.  Let |metadata| be the result of <a href="#get-the-strongest-metadata">
       getting the strongest metadata from |parsedMetadata|</a>.
-  5.  For each |item| in |metadata|:
+  4.  For each |item| in |metadata|:
       1.  Let |algorithm| be the |alg| component of
           |item|.
       2.  Let |expectedValue| be the |val| component of
@@ -419,7 +413,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
           </a>.
       4.  If |actualValue| is a case-sensitive match for
           |expectedValue|, return `true`.
-  6.  Return `false`.
+  5.  Return `false`.
 
   This algorithm allows the user agent to accept multiple, valid strong hash
   functions. For example, a developer might write a `script` element such as:

--- a/index.bs
+++ b/index.bs
@@ -355,27 +355,32 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
 
   1.  Let |result| be the empty set.
   2.  Let |empty| be equal to `true`.
-  3.  For each |token| returned by <a lt="strictly split">splitting |metadata| on
-      spaces</a>:
+  3.  For each |item| returned by <a lt="strictly split">splitting |metadata|
+      on spaces</a>:
       1.  Set |empty| to `false`.
-      2.  Let |position| point at the first character of |token|.
-      3.  <a lt="collect a sequence of code points">Collect a sequence of code
-          points</a> that are not equal to U+003F (?) from |token| given
-          |position|, and let the resulting sequence be the |hash-expresssion|.
-      4.  Let |option-expression| be the substring of *token* from the code
-          point at |position| + 1 by <a lt="code unit substring to the end of
-          the string">code unit substring</a>.
-      5.  Let |position| point at the first character of |hash-expression|.
-      6.  <a lt="collect a sequence of code points">Collect a sequence of code
-          points</a> that are not equal to U+002D (-) from |hash-expression|
-          given |position|, and let the resulting sequence be the |algorithm|.
-      7.  Let |base64-value| be the substring of |hash-expression| from the code
-          point at |position| + 1 <a lt="code unit substring to the end of the
-          string">code unit substring</a>.
-      8.  If either |algorithm| or |base64-value| is empty, [=continue=] the
-          next |token|.
-      9.  If |algorithm| is a hash function recognized by the user agent, add
-          the parsed |token| to |result|.
+      
+      2.  let |option-expression| be the empty string.
+      3.  Let |tokenlist| be the result of <a lt="strictly split">splitting
+          |item| on U+003F (?)</a>.
+      4.  Let |hash-expression| be the |tokenlist|[0].
+      5.  If |tokenlist|[1] exists, let |option-expression| be the
+          |tokenlist|[1].
+      
+      6.  Let |base64-value| be the empty string. 
+      7.  Let |tokenlist| be the result of <a lt="strictly split">splitting
+          |hash-expression| on U+002D (-)</a>.
+      8.  Let |algorithm| be the |tokenlist|[0].
+      9.  If |tokenlist|[1] exists, set |base64-value| be the |tokenlist|[1].
+      10.  If |algorithm| is not a hash function recognized by the user agent,
+           [=continue=] the next |item|.
+      11. Let |metadata| be a map with its keys initialized as follows:
+          : "`alg`"
+          :: |algorithm|
+          : "`val`"
+          :: |base64-value|
+          : "`opt`"
+          :: |option-expression|
+      12. Append |metadata| to |result|.
   4.  Return `no metadata` if |empty| is `true`, otherwise return
       |result|.
 

--- a/index.bs
+++ b/index.bs
@@ -358,28 +358,26 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   3.  For each |item| returned by <a lt="strictly split">splitting |metadata|
       on spaces</a>:
       1.  Set |empty| to `false`.
-      
-      2.  let |option-expression| be the empty string.
+      2.  Let |option-expression| be the empty string.
       3.  Let |tokenlist| be the result of <a lt="strictly split">splitting
           |item| on U+003F (?)</a>.
       4.  Let |hash-expression| be the |tokenlist|[0].
       5.  If |tokenlist|[1] exists, let |option-expression| be the
           |tokenlist|[1].
-      
-      6.  Let |base64-value| be the empty string. 
+      6.  Let |base64-value| be the empty string.
       7.  Let |tokenlist| be the result of <a lt="strictly split">splitting
           |hash-expression| on U+002D (-)</a>.
       8.  Let |algorithm| be the |tokenlist|[0].
       9.  If |tokenlist|[1] exists, set |base64-value| be the |tokenlist|[1].
       10.  If |algorithm| is not a hash function recognized by the user agent,
            [=continue=] the next |item|.
-      11. Let |metadata| be a map with its keys initialized as follows:
-          : "`alg`"
-          :: |algorithm|
-          : "`val`"
-          :: |base64-value|
-          : "`opt`"
-          :: |option-expression|
+      11.  Let |metadata| be a map with its keys initialized as follows:
+           : "`alg`"
+           :: |algorithm|
+           : "`val`"
+           :: |base64-value|
+           : "`opt`"
+           :: |option-expression|
       12. Append |metadata| to |result|.
   4.  Return `no metadata` if |empty| is `true`, otherwise return
       |result|.

--- a/index.bs
+++ b/index.bs
@@ -358,12 +358,24 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   3.  For each |token| returned by <a lt="strictly split">splitting |metadata| on
       spaces</a>:
       1.  Set |empty| to `false`.
-      2.  Parse |token| as a <a grammar>hash-with-options</a>.
-      3.  If |token| does not parse, [=continue=] to the next token.
-      4.  Let |algorithm| be the <a grammar>hash-algo</a> component of
-          |token|.
-      5.  If |algorithm| is a hash function recognized by the user
-          agent, add the parsed |token| to |result|.
+      2.  Let |position| point at the first character of |token|.
+      3.  <a lt="collect a sequence of code points">Collect a sequence of code
+          points</a> that are not equal to U+003F (?) from |token| given
+          |position|, and let the resulting sequence be the |hash-expresssion|.
+      4.  Let |option-expression| be the substring of *token* from the code
+          point at |position| + 1 by <a lt="code unit substring to the end of
+          the string">code unit substring</a>.
+      5.  Let |position| point at the first character of |hash-expression|.
+      6.  <a lt="collect a sequence of code points">Collect a sequence of code
+          points</a> that are not equal to U+002D (-) from |hash-expression|
+          given |position|, and let the resulting sequence be the |algorithm|.
+      7.  Let |base64-value| be the substring of |hash-expression| from the code
+          point at |position| + 1 <a lt="code unit substring to the end of the
+          string">code unit substring</a>.
+      8.  If either |algorithm| or |base64-value| is empty, [=continue=] the
+          next |token|.
+      9.  If |algorithm| is a hash function recognized by the user agent, add
+          the parsed |token| to |result|.
   4.  Return `no metadata` if |empty| is `true`, otherwise return
       |result|.
 

--- a/index.bs
+++ b/index.bs
@@ -357,21 +357,21 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
       |metadata| on spaces:
       1.  Let |hash-with-opt-token-list| be the result of
           <a lt="strictly split">splitting</a> |item| on U+003F (?).
-      2.  Let |hash-expression| be the |hash-with-opt-token-list|[0].
+      2.  Let |hash-expression| be |hash-with-opt-token-list|[0].
       3.  Let |base64-value| be the empty string.
       4.  Let |hash-expr-token-list| be the result of
           <a lt="strictly split">splitting</a> |hash-expression| on U+002D (-).
-      5.  Let |algorithm| be the |hash-expr-token-list|[0].
+      5.  Let |algorithm| be |hash-expr-token-list|[0].
       6.  If |hash-expr-token-list|[1] <a for=list>exists</a>, set
-          |base64-value| be the |hash-expr-token-list|[1].
+          |base64-value| to |hash-expr-token-list|[1].
       7.  If |algorithm| is not a hash function recognized by the user agent,
-           [=continue=] the next |item|.
+           [=continue=].
       8. Let |metadata| be the ordered map  «["alg" → |algorithm|,
          "val" → |base64-value|]».
 
-         Note: Since no `options` are not defined(see the
-         [[#integrity-metadata-description]]), corresponding entry is not set in
-         |metadata|. If `options` are defined in a future version of the spec,
+         Note: Since no `options` are defined (see the
+         [[#integrity-metadata-description]]), a corresponding entry is not set
+         in |metadata|. If `options` are defined in a future version,
          |hash-with-opt-token-list|[1] can be utilized as `options`.
 
       9. <a for=list>Append</a> |metadata| to |result|.
@@ -400,14 +400,12 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
 
   1.  Let |parsedMetadata| be the result of
       <a href="#parse-metadata">parsing |metadataList|</a>.
-  2.  If |parsedMetadata| is the empty set, return `true`.
+  2.  If |parsedMetadata| [=set/is empty=] set, return `true`.
   3.  Let |metadata| be the result of <a href="#get-the-strongest-metadata">
       getting the strongest metadata from |parsedMetadata|</a>.
   4.  For each |item| in |metadata|:
-      1.  Let |algorithm| be the |alg| component of
-          |item|.
-      2.  Let |expectedValue| be the |val| component of
-          |item|.
+      1.  Let |algorithm| be the |item|["alg"].
+      2.  Let |expectedValue| be the |item|["val"].
       3.  Let |actualValue| be the result of <a
           href="#apply-algorithm-to-response">applying |algorithm| to |bytes|
           </a>.


### PR DESCRIPTION
This modifies "3.3.2 parse metadata" to parse metadata using primitives from https://infra.spec.whatwg.org/#string instead of ABNF grammar from https://w3c.github.io/webappsec-subresource-integrity/#grammardef-hash-with-options. This makes it clear that the user agent does not need to validate the base64 digest contained in the metadata. Also, since it induces fail-open for invalid metadata, the compatibility of the SRI is guaranteed in the future.

Issue number : #84


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/baek9/webappsec-subresource-integrity/pull/110.html" title="Last updated on Nov 25, 2021, 4:15 PM UTC (e9121ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/110/94f3b3e...baek9:e9121ba.html" title="Last updated on Nov 25, 2021, 4:15 PM UTC (e9121ba)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/baek9/webappsec-subresource-integrity/pull/110.html" title="Last updated on Nov 30, 2022, 10:51 AM UTC (fba0c07)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/110/bde5526...baek9:fba0c07.html" title="Last updated on Nov 30, 2022, 10:51 AM UTC (fba0c07)">Diff</a>