### PR TITLE
Fix a misaligned index number

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -404,7 +404,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
           </a>.
       4.  If |actualValue| is a case-sensitive match for
           |expectedValue|, return `true`.
-  7.  Return `false`.
+  6.  Return `false`.
 
   This algorithm allows the user agent to accept multiple, valid strong hash
   functions. For example, a developer might write a `script` element such as:


### PR DESCRIPTION
This fixes the misaligned index number found in [3.3.4 Do bytes match metadataList?](https://w3c.github.io/webappsec-subresource-integrity/#does-response-match-metadatalist). Bikeshed seems to fix it automatically, but it would be nice to fix it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/baek9/webappsec-subresource-integrity/pull/111.html" title="Last updated on Jan 6, 2022, 11:43 PM UTC (7939ef4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/111/94f3b3e...baek9:7939ef4.html" title="Last updated on Jan 6, 2022, 11:43 PM UTC (7939ef4)">Diff</a>