### PR TITLE
Define SRI Reports to inform site operators of integrity check failures

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -480,7 +480,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   ## Handling integrity violations ## {#handling-integrity-violations}
 
   The user agent will refuse to render or execute responses that fail an integrity
-  check, instead returning a network error as defined in Fetch [[!Fetch]].
+  check, instead returning a network error as defined in Fetch [[!Fetch]], and may send an <a>sri report</a>.
 
   Note: On a failed integrity check, an `error` event is fired. Developers
   wishing to provide a canonical fallback resource (e.g., a resource not served
@@ -562,6 +562,30 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   common usernames, and specify those hashes while repeatedly attempting
   to load the document. A successful load would confirm that the attacker
   has correctly guessed the username.
+
+  <!-- ####################################################################### -->
+
+  # SRI Reports # {#sri-report}
+
+  <dfn>SRI Reports</dfn> indicate that the user agent refused to render or execute a response that failed an integrity check.
+
+  <a>SRI Reports</a> are a type of [=report=] and have the <a>report type</a> "sri".
+
+  <pre class="idl">
+    [Exposed=(Window,Worker)]
+    interface SriReportBody : ReportBody {
+      [Default] object toJSON();
+      readonly attribute USVString blockedURL;
+      readonly attribute DOMString? integrityAttribute;
+    };
+  </pre>
+
+  :  {{blockedURL}}
+  :: The URL of the resource that failed the integrity check.
+  :  {{integrityAttribute}}
+  :: The integrity attribute of the element.
+
+  <a>SRI Reports</a>, if sent, must be sent to a <a lt="endpoint">reporting endpoint</a> with a name of <code>sri</code> and must only be sent as the result of a failed integrity check and not any other error to ensure that no privacy or security risk is introduced.
 
   <!-- ####################################################################### -->
 


### PR DESCRIPTION
This PR defines SRI Reports, a mechanism to provide site operators with the ability to be notified about integrity check failures for resources they are loading. It will use the [Reporting API](https://www.w3.org/TR/reporting-1/) to dispatch reports.

If assets your site depends on have been modified and fail the integrity check, there is currently no reliable way for a site operator to know. This is raised as a concern on a somewhat regular basis to me as the founder of [Report URI](https://report-uri.com) where customers wish to implement SRI, but are surprised to learn that there is no feedback mechanism for failures. We have explored several methods to achieve this with JavaScript, but this is undesirable for various reasons, including the requirement to deploy more JavaScript and the difficulty of reliably detecting integrity check failures. This same problem was also raised in a recent whitepaper [1] where the authors had the following to say:

> Takeaways: It is imperative for new standards, particular security
standards, to possess built-in reporting mechanisms. Surprisingly,
it was possible for SRI misconfigurations of first-party scripts to
remain unnoticed for multiple months.

There is further discussion in #20 about the benefits of such a mechanism and how to avoid concerns around security and privacy impacts, which have been considered for this proposal.

Fix #20 

[1] [The More Things Change, the More They Stay the Same: Integrity of Modern JavaScript](https://securitee.org/files/jsintegrity_www2023.pdf)