### PR TITLE
Editorial updates

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -18,8 +18,8 @@ Group: webappsec
 Repository: w3c/webappsec-subresource-integrity
 Indent: 2
 Version History: https://github.com/w3c/webappsec-subresource-integrity/commits/gh-pages
-!Implementation status: <a href="https://code.google.com/p/chromium/issues/detail?id=355467">Blink/Chromium</a><br /><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=992096">Gecko</a>
-!Implementation report: <a href="https://github.com/w3c/webappsec-subresource-integrity/wiki/Links">https://github.com/w3c/webappsec-subresource-integrity/wiki/Links</a>
+WPT Path Prefix: /subresource-integrity/
+WPT Display: closed
 
 Markup Shorthands: css off, markdown on
 Ignored Vars: src, resource, val
@@ -109,6 +109,10 @@ spec:csp3; type:grammar; text:base64-value
   Scripts, of course, are not the only response type which would benefit
   from integrity validation. The scheme specified here also applies to `link`
   and future versions of this specification are likely to expand this coverage.
+
+  <wpt>
+    subresource-integrity.html
+  </wpt>
 
   ## Goals ## {#goals}
 

--- a/index.bs
+++ b/index.bs
@@ -329,15 +329,15 @@ spec:csp3; type:grammar; text:base64-value
   1.  Let |result| be the empty set.
   2.  For each |item| returned by <a lt="strictly split">splitting</a>
       |metadata| on spaces:
-      1.  Let |hash-with-opt-token-list| be the result of
+      1.  Let |expression-and-options| be the result of
           <a lt="strictly split">splitting</a> |item| on U+003F (?).
-      2.  Let |hash-expression| be |hash-with-opt-token-list|[0].
+      2.  Let |algorithm-expression| be |expression-and-options|[0].
       3.  Let |base64-value| be the empty string.
-      4.  Let |hash-expr-token-list| be the result of
-          <a lt="strictly split">splitting</a> |hash-expression| on U+002D (-).
-      5.  Let |algorithm| be |hash-expr-token-list|[0].
-      6.  If |hash-expr-token-list|[1] <a for=list>exists</a>, set
-          |base64-value| to |hash-expr-token-list|[1].
+      4.  Let |algorithm-and-value| be the result of
+          <a lt="strictly split">splitting</a> |algorithm-expression| on U+002D (-).
+      5.  Let |algorithm| be |algorithm-and-value|[0].
+      6.  If |algorithm-and-value|[1] <a for=list>exists</a>, set
+          |base64-value| to |algorithm-and-value|[1].
       7.  If |algorithm| is not a hash function recognized by the user agent,
            [=continue=].
       8. Let |metadata| be the ordered map  «["alg" → |algorithm|,
@@ -346,7 +346,7 @@ spec:csp3; type:grammar; text:base64-value
          Note: Since no `options` are defined (see the
          [[#integrity-metadata-description]]), a corresponding entry is not set
          in |metadata|. If `options` are defined in a future version,
-         |hash-with-opt-token-list|[1] can be utilized as `options`.
+         |expression-and-options|[1] can be utilized as `options`.
 
       9. <a for=list>Append</a> |metadata| to |result|.
   3.  Return |result|.

--- a/index.bs
+++ b/index.bs
@@ -1,12 +1,10 @@
 <pre class="metadata">
 Title: Subresource Integrity
 Status: ED
-Deadline: 2015-12-15
 ED: https://w3c.github.io/webappsec-subresource-integrity/
 TR: http://www.w3.org/TR/SRI/
-Previous Version: http://www.w3.org/TR/2015/WD-SRI-20151006/
 Shortname: SRI
-Level: 1
+Level: none
 Editor: Devdatta Akhawe, Dropbox Inc., http://devd.me, dev.akhawe@gmail.com
 Editor: Frederik Braun 68466, Mozilla, https://frederik-braun.com, fbraun@mozilla.com
 Editor: François Marier, Mozilla, https://fmarier.org, francois@mozilla.com

--- a/index.bs
+++ b/index.bs
@@ -99,11 +99,11 @@ spec:csp3; type:grammar; text:base64-value
   `script` element, like so:
 
   <div class="example">
-  <pre>
-    &lt;script src="https://example.com/example-framework.js"
+  <xmp highlight="html">
+    <script src="https://example.com/example-framework.js"
             integrity="sha384-Li9vy3DqF8tnTXuiaAJuML3ky+er10rcgNR/VqsVpcw+ThHmYcwiB1pbOxEbzJr7"
-            crossorigin="anonymous"&gt;&lt;/script&gt;
-  </pre>
+            crossorigin="anonymous"></script>
+  </xmp>
   </div>
 
   Scripts, of course, are not the only response type which would benefit
@@ -138,11 +138,11 @@ spec:csp3; type:grammar; text:base64-value
       <a>integrity metadata</a> is added to the `link` element included on the page:
 
       <div class="example">
-      <pre>
-          &lt;link rel="stylesheet" href="https://site53.example.net/style.css"
+      <xmp highlight="html">
+          <link rel="stylesheet" href="https://site53.example.net/style.css"
                 integrity="sha384-+/M6kredJcxdsqkczBUjMLvqyHb1K/JThDXWsBVxMEeZHEaMKEOEct339VItX1zB"
-                crossorigin="anonymous"&gt;
-      </pre>
+                crossorigin="anonymous">
+      </xmp>
       </div>
 
   *   An author wants to include JavaScript provided by a third-party
@@ -151,11 +151,11 @@ spec:csp3; type:grammar; text:base64-value
       the script, and adds it to the `script` element:
 
       <div class="example">
-      <pre>
-          &lt;script src="https://analytics-r-us.example.com/v1.0/include.js"
+      <xmp highlight="html">
+          <script src="https://analytics-r-us.example.com/v1.0/include.js"
                   integrity="sha384-MBO5IDfYaE6c6Aao94oZrIOiC6CGiSN2n4QUbHNPhzk5Xhm0djZLQqTpL0HzTUxk"
-                  crossorigin="anonymous"&gt;&lt;/script&gt;
-      </pre>
+                  crossorigin="anonymous"></script>
+      </xmp>
       </div>
 
   *   A user agent wishes to ensure that JavaScript code running in high-privilege HTML
@@ -233,9 +233,9 @@ spec:csp3; type:grammar; text:base64-value
   as follows:
 
   <div class="example">
-  <pre>
+  <xmp>
       sha384-H8BRh8j48O9oYatfu5AZzq6A9RINhZO5H16dQZngK7T62em8MUt1FLm52t+eX6xO
-  </pre>
+  </xmp>
   </div>
 
   <div class="note">
@@ -244,9 +244,9 @@ spec:csp3; type:grammar; text:base64-value
   available. The example in this section is the result of the following command
   line:
 
-  <pre>
+  <xmp highlight="shell">
       echo -n "alert('Hello, world.');" | openssl dgst -sha384 -binary | openssl base64 -A
-  </pre>
+  </xmp>
   </div>
 
   ## Cryptographic hash functions ## {#hash-functions}
@@ -269,21 +269,21 @@ spec:csp3; type:grammar; text:base64-value
   by either of the following hash expressions:
 
   <div class="example">
-  <pre>
+  <xmp>
       sha384-H8BRh8j48O9oYatfu5AZzq6A9RINhZO5H16dQZngK7T62em8MUt1FLm52t+eX6xO
       sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzCinRE7Af1ofPrw==
-  </pre>
+  </xmp>
   </div>
 
   Authors may choose to specify both, for example:
 
   <div class="example">
-  <pre>
-      &lt;script src="hello_world.js"
+  <xmp highlight="html">
+      <script src="hello_world.js"
          integrity="sha384-H8BRh8j48O9oYatfu5AZzq6A9RINhZO5H16dQZngK7T62em8MUt1FLm52t+eX6xO
                     sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzCinRE7Af1ofPrw=="
-         crossorigin="anonymous"&gt;&lt;/script&gt;
-  </pre>
+         crossorigin="anonymous"></script>
+  </xmp>
   </div>
 
   In this case, the user agent will choose the strongest hash function in the
@@ -393,12 +393,12 @@ spec:csp3; type:grammar; text:base64-value
   functions. For example, a developer might write a `script` element such as:
 
   <div class="example">
-  <pre>
-      &lt;script src="https://example.com/example-framework.js"
+  <xmp highlight="html">
+      <script src="https://example.com/example-framework.js"
               integrity="sha384-Li9vy3DqF8tnTXuiaAJuML3ky+er10rcgNR/VqsVpcw+ThHmYcwiB1pbOxEbzJr7
                          sha384-+/M6kredJcxdsqkczBUjMLvqyHb1K/JThDXWsBVxMEeZHEaMKEOEct339VItX1zB"
-              crossorigin="anonymous"&gt;&lt;/script&gt;
-  </pre>
+              crossorigin="anonymous"></script>
+  </xmp>
   </div>
 
   which would allow the user agent to accept two different content payloads, one
@@ -528,9 +528,9 @@ spec:csp3; type:grammar; text:base64-value
   static resource. Consider a JSON response that looks like this:
 
   <div class="example">
-  <pre>
+  <xmp highlight="json">
       {'status': 'authenticated', 'username': 'admin'}
-  </pre>
+  </xmp>
   </div>
 
   An attacker could precompute hashes for the response with a variety of

--- a/index.bs
+++ b/index.bs
@@ -31,40 +31,15 @@ spec: ABNF; urlPrefix: https://tools.ietf.org/html/rfc5234
     text: VCHAR; url: appendix-B.1
     text: WSP; url: appendix-B.1
   type: grammar
-    text: ALPHA; url: appendix-B.1
-    text: DIGIT; url: appendix-B.1
     text: VCHAR; url: appendix-B.1
     text: WSP; url: appendix-B.1
-
-
-spec: Fetch; urlPrefix: https://fetch.spec.whatwg.org
-  type: dfn
-    text: fetch; url: concept-fetch
-    text: request; url: concept-request
-    text: response type; url: concept-response-type
-    text: destination; url: concept-request-destination
-
-spec: HTML5; urlPrefix: http://www.w3.org/TR/html5/
-  type: dfn
-    urlPrefix: document-metadata.html
-      text: obtain a resource; url: concept-link-obtain
-    urlPrefix: infrastructure.html
-      text: CORS settings attribute; url: #cors-settings-attributes
-      text: reflect; url: #reflect
-    urlPrefix: scripting-1.html
-      text: prepare a script; url: #prepare-a-script
-      text: splitting tokens on spaces; url: split-a-string-on-spaces
 
 spec: RFC7234; urlPrefix: https://tools.ietf.org/html/rfc7234
   type: dfn
     text: Cache-Control; url: section-5.2
     text: no-transform; url: section-5.2.1.6
 
-spec: SECURE-CONTEXTS; urlPrefix: http://www.w3.org/TR/powerful-features/
-  type: dfn
-    text: Secure Context; urlPrefix: #
-
-spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf
+spec: SHA2; urlPrefix: https://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf
   type: dfn
     text: SHA-1; url: #
     text: SHA-2; url: #
@@ -72,16 +47,12 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
     text: SHA-384; url: #
     text: SHA-512; url: #
 </pre>
+<pre class="link-defaults">
+spec:csp3; type:grammar; text:base64-value
+</pre>
 
 <pre class="biblio">
 {
-  "SECURE-CONTEXTS": {
-    "authors": [ "Mike West", "Yan Zhu" ],
-    "href": "https://w3c.github.io/webappsec-secure-contexts/",
-    "title": "Secure Contexts",
-    "status": "WD",
-    "publisher": "W3C"
-  },
   "SHA2": {
     "href": "http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf",
     "title": "FIPS PUB 180-4, Secure Hash Standard"
@@ -213,10 +184,11 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   specified in RFC5234. [[!ABNF]]
 
   <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">Appendix B.1</a> of
-  [[!ABNF]] defines <a>VCHAR</a> (printing characters).
+  [[!ABNF]] defines the <a>VCHAR</a> (printing characters) and <a>WSP</a>
+  (whitespace) rules.
 
-  <a>WSP</a> (white space) characters are defined in <a href="http://www.w3.org/TR/html5/infrastructure.html#space-character">Section 2.4.1 Common parser idioms</a> of the HTML 5 specification as
-  <code>White_Space characters</code>. [[!HTML5]]
+  Content Security Policy defines the <a grammar>`base64-value`</a> and
+  <a grammar>`hash-algorithm`</a> rules. [[!CSP]]
 
   </section>
 
@@ -232,8 +204,8 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   ## Integrity metadata ## {#integrity-metadata-description}
 
   To verify the integrity of a response, a user agent requires <dfn>integrity
-  metadata</dfn> as part of the <a>request</a>. This metadata consists of the
-  following pieces of information:
+  metadata</dfn> as part of the <a for=/>request</a>. This metadata consists of
+  the following pieces of information:
 
   * cryptographic hash function ("alg")
   * <a>digest</a> ("val")
@@ -461,9 +433,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
       <dfn>integrity-metadata</dfn> = *<a>WSP</a> <a>hash-with-options</a> *(1*<a>WSP</a> <a>hash-with-options</a> ) *<a>WSP</a> / *<a>WSP</a>
       <dfn>hash-with-options</dfn>  = <a>hash-expression</a> *("?" <a>option-expression</a>)
       <dfn>option-expression</dfn>  = *<a>VCHAR</a>
-      <dfn>hash-algo</dfn>          = &lt;hash-algo production from [Content Security Policy Level 2, section 4.2]&gt;
-      <dfn>base64-value</dfn>       = &lt;base64-value production from [Content Security Policy Level 2, section 4.2]&gt;
-      <dfn>hash-expression</dfn>    = <a>hash-algo</a> "-" <a>base64-value</a>
+      <dfn>hash-expression</dfn>    = <a grammar>hash-algorithm</a> "-" <a grammar>base64-value</a>
   </pre>
 
   `option-expression`s are associated on a per `hash-expression` basis and are
@@ -537,8 +507,9 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
 
   ## Cross-origin data leakage ## {#cross-origin-data-leakage}
 
-  This specification requires the <a>CORS settings attribute</a> to be present on
-  integrity-protected cross-origin requests. If that requirement were omitted,
+  This specification requires integrity-protected cross-origin requests to use the
+  <a>CORS protocol</a> to ensure that the resource's content is explicitly shared
+  with the requestor. If that requirement were omitted,
   attackers could violate the <a
   href="http://www.w3.org/Security/wiki/Same_Origin_Policy">same-origin policy</a>
   and determine whether a cross-origin resource has certain content.


### PR DESCRIPTION
This PR pulls together some small editorial updates that remove hard-coded links (thereby shifting to Infra and HTML in some places), and adjusts some variable names for future extensibility. Nothing crazy.

I've broken the changes out into a few distinct commits in the hopes that that makes this simpler to review.

WDYT, @mozfreddyb?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/pull/125.html" title="Last updated on Oct 7, 2024, 10:27 AM UTC (bbd1fee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/125/5aab13c...bbd1fee.html" title="Last updated on Oct 7, 2024, 10:27 AM UTC (bbd1fee)">Diff</a>