### PR TITLE
Revive require-sri-for for scripts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -349,7 +349,6 @@ spec:csp3; type:grammar; text:base64-value
   The following list contains the set of <dfn noexport>known tokens</dfn>:
 
     * `script` requires SRI for scripts
-    * `style` requires SRI for style sheets
 
 
   ### Parsing `require-sri-for` ### {#parse-require-sri-for}
@@ -382,8 +381,8 @@ spec:csp3; type:grammar; text:base64-value
 
       Note: This logic means that request with matched <a>destination</a> and missing <a>integrity metadata</a>
       will be blocked even if it is not currently possible to set it's <a>integrity metadata</a>.
-      Such requests are originated by, for example, <code>importScripts()</code>, CSS' <code>@import</code>,
-      or `script`/`style` elements without crossorigin content attribute.
+      Such requests are originated by, for example, <code>importScripts()</code>,
+      or `script` elements without crossorigin content attribute.
 
 
   3.  Return "Allowed".
@@ -392,7 +391,7 @@ spec:csp3; type:grammar; text:base64-value
     A page with the following Content Security Policy:
 
     <pre>
-      Content-Security-Policy: <a>require-sri-for</a> script style
+      Content-Security-Policy: <a>require-sri-for</a> script
     </pre>
 
     is equivalent to Content Security Policy delivered through `<meta>`
@@ -400,12 +399,12 @@ spec:csp3; type:grammar; text:base64-value
 
     <pre>
       &lt;meta http-equiv="Content-Security-Policy"
-            content="<a>require-sri-for</a> script style"&gt;
+            content="<a>require-sri-for</a> script"&gt;
     </pre>
 
 
     and requires <a>integrity metadata</a> be present in `script`
-    and `link` HTML elements that contain `src` attribute.
+    elements that contain `src` attribute.
   </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -32,6 +32,17 @@ spec: ABNF; urlPrefix: https://tools.ietf.org/html/rfc5234
     text: VCHAR; url: appendix-B.1
     text: WSP; url: appendix-B.1
 
+spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
+  type: dfn
+    text: Content Security Policy; urlPrefix: #
+    text: policy; url: policy
+    text: directive; url: directives
+    text: value; for: directive; url: directive-value
+    text: pre-request check; url: directive-pre-request-check
+    text: create a violation object for global; url: create-violation-for-global
+    text: report violation; url: report-violation
+    text: disposition; for: policy
+
 spec: RFC7234; urlPrefix: https://tools.ietf.org/html/rfc7234
   type: dfn
     text: Cache-Control; url: section-5.2
@@ -322,7 +333,83 @@ spec:csp3; type:grammar; text:base64-value
   supported by this specification.
 
 
-  ## Response verification algorithms ## {#verification-algorithms}
+  ## Request verification algorithms ## {#request-verification-algorithms}
+
+  ### Opting-in  ### {#opt-in-require-sri-for}
+
+  Authors may opt a {{Document}} to require SRI metadata be present for 
+  some resource types via a <dfn export>require-sri-for</dfn> <a>Content
+  Security Policy</a> directive defined by the following ABNF grammar:
+
+  <pre dfn-type="grammar" link-type="grammar">
+      directive-name  = "require-sri-for"
+      directive-value = <a grammar>token</a> *( <a>RWS</a> <a>token</a> )
+  </pre>
+
+  The following list contains the set of <dfn noexport>known tokens</dfn>:
+
+    * `script` requires SRI for scripts
+    * `style` requires SRI for style sheets
+
+
+  ### Parsing `require-sri-for` ### {#parse-require-sri-for}
+
+  Given a string (|token list|), this algorithm returns a list of resource
+  types which will require integrity checks:
+
+  1.  Let the set of |protected resource types| that require SRI be the empty set.
+
+  2.  For each |token| in the result of <a lt="split a string on spaces">
+      splitting |token list| on spaces</a>, if token matches the grammar
+      for <a>require-sri-for</a> and is a <a>ASCII case-insensitive match</a>
+      for any of the <a>known token</a>s, add |token| to |protected resource types|.
+      Otherwise, ignore the token.
+
+  3.  Return the set of |protected resource types|.
+
+  ### Apply |algorithm| to |request| ### {#apply-algorithm-to-request}
+
+  This directive’s <a>pre-request check</a> is as follows:
+
+  Given a <a>request</a> (|request|) and a <a>policy</a> (|policy|):
+
+  1.  Let |protected resource types| be the result of executing
+      [[#parse-require-sri-for]] on this <a>directive</a>'s <a for="directive">value</a>.
+
+  2.  If |request|'s <a>destination</a> is a <a>ASCII case-insensitive match</a> for at least
+      one token in |protected resource types|, and |request|'s integrity metadata
+      is the empty string, return "Blocked".
+
+      Note: This logic means that request with matched <a>destination</a> and missing <a>integrity metadata</a>
+      will be blocked even if it is not currently possible to set it's <a>integrity metadata</a>.
+      Such requests are originated by, for example, <code>importScripts()</code>, CSS' <code>@import</code>,
+      or `script`/`style` elements without crossorigin content attribute.
+
+
+  3.  Return "Allowed".
+
+  <div class="example">
+    A page with the following Content Security Policy:
+
+    <pre>
+      Content-Security-Policy: <a>require-sri-for</a> script style
+    </pre>
+
+    is equivalent to Content Security Policy delivered through `<meta>`
+    element:
+
+    <pre>
+      &lt;meta http-equiv="Content-Security-Policy"
+            content="<a>require-sri-for</a> script style"&gt;
+    </pre>
+
+
+    and requires <a>integrity metadata</a> be present in `script`
+    and `link` HTML elements that contain `src` attribute.
+  </div>
+
+
+  ## Response verification algorithms ## {#response-verification-algorithms}
 
   ### Apply |algorithm| to |bytes| ### {#apply-algorithm-to-response}
 
@@ -546,6 +633,17 @@ spec:csp3; type:grammar; text:base64-value
   common usernames, and specify those hashes while repeatedly attempting
   to load the document. A successful load would confirm that the attacker
   has correctly guessed the username.
+
+
+  <section>
+    <h2 id="iana-considerations">IANA Considerations</h2>
+
+    The Content Security Policy Directive registry should be updated with the
+    following directives and references [[!RFC7762]]:
+
+    :   <a>`require-sri-for`</a>
+    ::  This document (see [[#opt-in-require-sri-for]])
+  </section>
 
   <!-- ####################################################################### -->
 


### PR DESCRIPTION
This ~reverts https://github.com/w3c/webappsec-subresource-integrity/pull/82/files, which reverted `require-sri-for`.

It only includes the `script` token, as it has a clear [use case](https://docs.google.com/document/d/1RcUpbpWPxXTyW0Qwczs9GCTLPD3-LcbbhL4ooBUevTM/edit?tab=t.0).

I believe the reasons for removing `require-sri-for` are losing ground:
* We can now set [integrity for dynamic ES modules](https://shopify.engineering/shipping-support-for-module-script-integrity-in-chrome-safari)
* [Signature-based SRI](https://wicg.github.io/signature-based-sri/) will enable us to set integrity checks for evergreen scripts

Integrity checks for workers are still missing, but there's work underway to [enable importmaps in workers](https://github.com/whatwg/html/pull/10858) which will give us that, at least for some assets.