### PR TITLE
Prepare for an FPWD of SRI2.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4,11 +4,11 @@ Status: ED
 ED: https://w3c.github.io/webappsec-subresource-integrity/
 TR: http://www.w3.org/TR/SRI/
 Shortname: SRI
-Level: none
-Editor: Devdatta Akhawe, Dropbox Inc., http://devd.me, dev.akhawe@gmail.com
+Level: 2
 Editor: Frederik Braun 68466, Mozilla, https://frederik-braun.com, fbraun@mozilla.com
-Editor: François Marier, Mozilla, https://fmarier.org, francois@mozilla.com
-Editor: Joel Weinberger, Google Inc., https://joelweinberger.us, jww@google.com
+Former Editor: Devdatta Akhawe, Dropbox Inc., http://devd.me, dev.akhawe@gmail.com
+Former Editor: François Marier, Mozilla, https://fmarier.org, francois@mozilla.com
+Former Editor: Joel Weinberger, Google Inc., https://joelweinberger.us, jww@google.com
 Abstract:
   This specification defines a mechanism by which user agents may verify that a
   fetched resource has been delivered without unexpected manipulation.


### PR DESCRIPTION
This PR labels the spec as "Level 2" (a formality, as we published the original under a W3C Process that doesn't allow us to update snapshotted CRs), and records editors' emeritus status.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/pull/132.html" title="Last updated on Mar 20, 2025, 8:29 AM UTC (48ac065)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/132/ac31b01...48ac065.html" title="Last updated on Mar 20, 2025, 8:29 AM UTC (48ac065)">Diff</a>