### PR TITLE
Add Integrity-Policy for scripts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -524,7 +524,7 @@ spec:csp3; type:grammar; text:base64-value
   ## Integrity-Policy ## {#integrity-policy-section}
   The `Integrity-Policy` and `Integrity-Policy-Report-Only` HTTP headers enable a document to
   enforce a policy regarding the integrity metadata requirements on all the subresources it
-  loads of certain <a>destinations</a>.
+  loads of certain <a for=request>destinations</a>.
 
   The headers' value is a <a>Dictionary</a> [[RFC9651]], with every member-value being an
   <a>inner list</a> of <a>tokens</a>.
@@ -534,22 +534,19 @@ spec:csp3; type:grammar; text:base64-value
 
   An <dfn>integrity policy struct</dfn>, is a <a>struct</a> that contains the following:
 
-    * <dfn>enforcement</dfn>, a string which is the empty string or "block". Initially "block".
     * <dfn>sources</dfn>, a list of <a>source</a>s, Initially empty.
-    * <dfn>destinations</dfn>, a list of <a>destination</a>s, Initially empty.
+    * <dfn>blocked destinations</dfn>, a list of <a>destination</a>s, Initially empty.
     * <dfn>endpoints</dfn>, a <a>list</a> of strings, initially empty.
 
   When <dfn>processing an integrity policy</dfn>, with |input|, do the following:
 
   1. Let |integrity policy| be a new <a>integrity policy struct</a>.
   1. Let |dictionary| be the result of <a>parsing a dictionary</a> with |input|.
-  1. If |dictionary|['enforcement'] exists:
-    1. If its value is "block", set |integrity policy|'s <a>enforcement</a> to "block".
-    1. Otherwise, set |integrity policy|'s <a>enforcement</a> to the empty string.
   1. If |dictionary|['sources'] does not exist or if its value <a for=list>contains</a> "inline",
      <a for=list>append</a> "inline" to |integrity policy|'s <a>sources</a>.
-  1. If |dictionary|['destinations'] exists:
-    1. If its value <a for=list>contains</a> "script", set |integrity policy|'s <a>destinations</a> to "script".
+  1. If |dictionary|['blocked-destinations'] exists:
+    1. If its value <a for=list>contains</a> "script",
+       <a for=list>append</a> "script" to |integrity policy|'s <a>blocked destinations</a>.
   1. if |dictionary|['endpoints'] exists:
     1. Set |integrity policy|'s <a>endpoints</a> to |dictionary|['endpoints'].
   1. return |integrity policy|
@@ -578,13 +575,11 @@ spec:csp3; type:grammar; text:base64-value
   1. Let |report policy| be |policy container|'s <a>report only integrity policy</a>.
   1. Let |block| be a boolean, initially false.
   1. Let |report block| be a boolean, initially false.
-  1. if |policy|'s <a>enforcement</a> is "block"
-     and |policy|'s <a>source</a> is "inline"
-     and |policy|'s <a>destination</a> is equal to |request|'s <a for=request>destination</a>,
+  1. if |policy|'s <a>source</a> is "inline"
+     and |policy|'s <a>blocked destinations</a> <a for=list>contains</a> |request|'s <a for=request>destination</a>,
      set |block| to true.
-  1. if |report policy|'s <a>enforcement</a> is "block"
-     and |report policy|'s <a>source</a> is "inline"
-     and |report policy|'s <a>destination</a> is equal to |request|'s <a for=request>destination</a>,
+  1. if |report policy|'s <a>source</a> is "inline"
+     and |report policy|'s <a>blocked destinations</a> <a for=list>contains</a> |request|'s <a for=request>destination</a>,
      set |report block| to true.
   1. If |block| or |report block|, <a>report violation</a> with |request|, |block|, |report block|,
      |policy| and |report policy|.

--- a/index.bs
+++ b/index.bs
@@ -575,6 +575,8 @@ spec:csp3; type:grammar; text:base64-value
      return "Allowed".
   1. Let |policy| be |policy container|'s <a>integrity policy</a>.
   1. Let |report policy| be |policy container|'s <a>report only integrity policy</a>.
+  1. If both |policy| and |report policy| are empty <a>integrity policy struct</a>s, return "Allowed".
+  1. Assert that |request|'s <a for=request>client</a>'s <a>global object</a> is a <a>Window</a>. 
   1. Let |block| be a boolean, initially false.
   1. Let |report block| be a boolean, initially false.
   1. if |policy|'s <a>sources</a> <a for=list>contains</a> "inline"
@@ -661,6 +663,9 @@ spec:csp3; type:grammar; text:base64-value
 
   Add an extra step to <a>create a policy container from a fetch response</a> before it returns, that runs
   <a>parse Integrity-Policy headers</a> with <var ignore>response</var> and <var ignore>result</var>.
+
+  Note: The creation of a policy container only happens on navigation responses, but there's no
+        current way to assert that as part of the algorithm.
 
   Expand step 7 of <a>main fetch</a> to call <a>should request be blocked by integrity policy</a>
   and return a <a>network error</a> if it returns "blocked"

--- a/index.bs
+++ b/index.bs
@@ -32,6 +32,22 @@ spec: ABNF; urlPrefix: https://tools.ietf.org/html/rfc5234
     text: VCHAR; url: appendix-B.1
     text: WSP; url: appendix-B.1
 
+spec: INFRA; urlPrefix: https://infra.spec.whatwg.org
+  type: dfn
+    text: list; url: list
+
+spec: HTML; urlPrefix: https://html.spec.whatwg.org/C
+  type: dfn
+    text: policy container; url: policy-container
+
+spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
+  type: dfn
+    text: request; url: concept-request 
+    text: response; url: concept-response 
+    text: header list; url: concept-response-header-list
+    text: header; url: concept-header
+    text: main fetch; url: main-fetch
+
 spec: RFC7234; urlPrefix: https://tools.ietf.org/html/rfc7234
   type: dfn
     text: Cache-Control; url: section-5.2
@@ -54,6 +70,7 @@ spec: RFC9651; urlPrefix: https://tools.ietf.org/html/rfc9651
     text: Dictionary; url: name-dictionaries
     text: inner list; url: name-inner-lists
     text: token; url: name-tokens
+    text: parsing a dictionary; url: name-parsing-a-dictionary
 
 </pre>
 <pre class="link-defaults">
@@ -494,7 +511,7 @@ spec:csp3; type:grammar; text:base64-value
 
   <!-- ####################################################################### -->
   
-  ## Integrity-Policy ## {#integrity-policy}
+  ## Integrity-Policy ## {#integrity-policy-section}
   The `Integrity-Policy` and `Integrity-Policy-Report-Only` HTTP headers enable a document to
   enforce a policy regarding the integrity metadata requirements on all the subresources it
   loads of certain <a>destinations</a>.
@@ -508,39 +525,39 @@ spec:csp3; type:grammar; text:base64-value
     * <dfn>destination</dfn>, a string which is the empty string or "script". Initially the empty string.
     * <dfn>endpoints</dfn>, a <a>list</a> of strings, initially empty.
 
-  When <dfn>processing an integrity policy</dfn>, with |value|, do the following:
+  When <dfn>processing an integrity policy</dfn>, with |input|, do the following:
   1) Let |integrity policy| be a new <a>integrity policy struct</a>.
-  1) Let <var>dictionary</var> be the result of <a>parsing a dictionary</a> with |input|.
-  1) If dictionary['enforcement'] exists:
-    1) If its value is "block", set |integrity policy|'s |enforcement| to "block".
-    1) Otherwise, set |integrity policy|'s |enforcement| to the empty string.
-  1) If dictionary['sources'] exists:
-    1) If its value <a>contains</a> "inline", set |integrity policy|'s |source| to "inline".
-    1) Otherwise, set |integrity policy|'s |source| to the empty string.
-  1) If dictionary['destinations'] exists:
-    1) If its value <a>contains</a> "script", set |integrity policy|'s |destination| to "script".
-  1) if dictionary['endpoints'] exists:
-    1) Set |integrity policy|'s |endpoints| to dictionary['endpoints'].
+  1) Let |dictionary| be the result of <a>parsing a dictionary</a> with |input|.
+  1) If |dictionary|['enforcement'] exists:
+    1) If its value is "block", set |integrity policy|'s <a>enforcement</a> to "block".
+    1) Otherwise, set |integrity policy|'s <a>enforcement</a> to the empty string.
+  1) If |dictionary|['sources'] exists:
+    1) If its value <a>contains</a> "inline", set |integrity policy|'s <a>source</a> to "inline".
+    1) Otherwise, set |integrity policy|'s <a>source</a> to the empty string.
+  1) If |dictionary|['destinations'] exists:
+    1) If its value <a>contains</a> "script", set |integrity policy|'s <a>destination</a> to "script".
+  1) if |dictionary|['endpoints'] exists:
+    1) Set |integrity policy|'s <a>endpoints</a> to |dictionary|['endpoints'].
   1) return |integrity policy|
   
-  Each <a>Document</a> has an <dfn>integrity policy</dfn>, an <a>integrity policy struct</a>.
-  Each <a>Document</a> has an <dfn>integrity policy report only</dfn>, an <a>integrity policy struct</a>.
-
-  ### Parse Integrity-Policy headers
-  Given a <a>response<a> |response| and a <a>Document</a> |document|, do the following:
+  ### Parse Integrity-Policy headers ### {#parse-integrity-policy-headers-section}
+  To <dfn>parse Integrity-Policy headers</dfn>, given a <a>Response</a> |response|
+  and a <a>policy container</a> |container|, do the following:
   1) Let |headers| be |response|'s <a>header list</a>.
   1) If |headers| <a>contains</a> a <a>header</a> whose <a>header name</a> is "Integrity-Policy",
-     let |document|'s <a>integrity policy</a> be the result of running <a>processing an integrity policy</a>
+     let |container|'s <a>integrity policy</a> be the result of running <a>processing an integrity policy</a>
      with the corresponding <a>header value</a>.
   1) If |headers| <a>contains</a> a <a>header</a> whose <a>header name</a> is "Integrity-Policy-Report-Only",
-     let |document|'s <a>integrity policy report only</a> be the result of running <a>processing an integrity
+     let |container|'s <a>report only integrity policy</a> be the result of running <a>processing an integrity
      policy</a> with the corresponding <a>header value</a>.
   
-  ### Should request be blocked by Integrity Policy ### {#should-request-be-blocked-by-integrity-policy}
-  Given a <a>request</a> |request| and a <a>Document</a> |document|, do the following:
-  1) if |request|'s <a>integrity metadata</a> is not empty, return false.
-  1) Let |policy| be |document|'s <a>integrity policy</a>.
-  1) Let |report policy| be |document|'s <a>integrity policy report only</a>.
+  ### Should request be blocked by Integrity Policy ### {#should-request-be-blocked-by-integrity-policy-section}
+  To determine <dfn>should request be blocked by integrity policy</dfn>, given a <a>request</a> |request|,
+  do the following:
+  1) Let |policy container| be |request|'s <a>policy container</a>.
+  1) if |request|'s <a>integrity metadata</a> is not empty, return "Allowed".
+  1) Let |policy| be |policy container|'s <a>integrity policy</a>.
+  1) Let |report policy| be |policy container|'s <a>report only integrity policy</a>.
   1) Let |block| be a boolean, initially false.
   1) Let |report block| be a boolean, initially false.
   1) if |policy|'s <a>enforcement</a> is "block" and |policy|'s <a>source</a> is "inline" and |policy|'s
@@ -551,11 +568,27 @@ spec:csp3; type:grammar; text:base64-value
   1) If |block| or |report block|, <a>fire a violation event</a>.
   1) If |block|, <a>report violation</a> with |policy|'s <a>endpoints</a>.
   1) If |report block|, <a>report violation</a> with |report policy|'s <a>endpoints</a>.
+  1) If |block|, return "Blocked". Otherwise, return "Allowed".
  
   ### Fire a violation event ### {#fire-violation-event}
-  ### Report violatoin ### {#report-violation}
+  To <dfn>fire a violation event</dfn>, do the following:
+  1) TODO
 
-  ### Fetch integration ### {#fetch-integration}
+  ### Report violation ### {#report-violation-section}
+  To <dfn>report violation</dfn> given a <a>list</a> |endpoints|, do the following:
+  1) TODO do something with |endpoints|
+
+  ### Integration ### {#integration}
+
+  A <a>policy container</a> has extra items:
+  * <dfn>integrity policy</dfn>, an <a>integrity policy struct</a>.
+  * <dfn>report only integrity policy</dfn>, an <a>integrity policy struct</a>.
+
+  Add an extra step to <a>create a policy container from a fetch response</a> before it returns, that runs
+  <a>parse Integrity-Policy headers</a> with <var ignore>response</var> and <var ignore>result</var>.
+
+  Expand step 7 of <a>main fetch</a> to call <a>should request be blocked by integrity policy</a>
+  and return a <a>network error</a> if it returns "blocked"
 
   # Proxies # {#proxies}
 

--- a/index.bs
+++ b/index.bs
@@ -53,10 +53,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/C
 
 spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
-    text: request; url: concept-request 
-    text: response; url: concept-response 
-    text: header list; url: concept-response-header-list
-    text: header; url: concept-header
     text: main fetch; url: main-fetch
 
 spec: RFC7234; urlPrefix: https://tools.ietf.org/html/rfc7234
@@ -81,7 +77,6 @@ spec: RFC9651; urlPrefix: https://tools.ietf.org/html/rfc9651
     text: Dictionary; url: name-dictionaries
     text: inner list; url: name-inner-lists
     text: token; url: name-tokens
-    text: parsing a dictionary; url: name-parsing-a-dictionary
 
 </pre>
 <pre class="link-defaults">
@@ -530,8 +525,9 @@ spec:csp3; type:grammar; text:base64-value
   The headers' value is a <a>Dictionary</a> [[RFC9651]], with every member-value being an
   <a>inner list</a> of <a>tokens</a>.
   
-  A <dfn>source</dfn> is a string. The only possible value for it is "inline".
-  A <dfn>destination</dfn> is a string. The only possible value for it is "script".
+  A <dfn>source</dfn> is a string. The only possible value for it is "`inline`".
+
+  A <dfn>destination</dfn> is a string. The only possible value for it is "`script`".
 
   An <dfn>integrity policy struct</dfn>, is a <a>struct</a> that contains the following:
 
@@ -539,35 +535,36 @@ spec:csp3; type:grammar; text:base64-value
     * <dfn>blocked destinations</dfn>, a list of <a>destination</a>s, Initially empty.
     * <dfn>endpoints</dfn>, a <a>list</a> of strings, initially empty.
 
-  When <dfn>processing an integrity policy</dfn>, with |input|, do the following:
+  When <dfn>processing an integrity policy</dfn>, with |headers| and |header name|, do the following:
 
-  1. Let |integrity policy| be a new <a>integrity policy struct</a>.
-  1. Let |dictionary| be the result of <a>parsing a dictionary</a> with |input|.
-  1. If |dictionary|['sources'] does not exist or if its value <a for=list>contains</a> "inline",
-     <a for=list>append</a> "inline" to |integrity policy|'s <a>sources</a>.
-  1. If |dictionary|['blocked-destinations'] exists:
-    1. If its value <a for=list>contains</a> "script",
-       <a for=list>append</a> "script" to |integrity policy|'s <a>blocked destinations</a>.
-  1. if |dictionary|['endpoints'] exists:
-    1. Set |integrity policy|'s <a>endpoints</a> to |dictionary|['endpoints'].
-  1. return |integrity policy|
+  1. Let |integrityPolicy| be a new <a>integrity policy struct</a>.
+  1. Let |dictionary| be the result of <a>getting a structured field value</a> from |headers|
+     given |header name| and "`dictionary`".
+  1. If |dictionary|["`sources`"] does not exist or if its value <a for=list>contains</a> "`inline`",
+     <a for=list>append</a> "`inline`" to |integrityPolicy|'s <a>sources</a>.
+  1. If |dictionary|["`blocked-destinations`"] exists:
+    1. If its value <a for=list>contains</a> "`script`",
+       <a for=list>append</a> "`script`" to |integrityPolicy|'s <a>blocked destinations</a>.
+  1. If |dictionary|["`endpoints`"] <a for=map>exists</a>:
+    1. Set |integrityPolicy|'s <a>endpoints</a> to |dictionary|['endpoints'].
+  1. Return |integrityPolicy|.
   
   ### Parse Integrity-Policy headers ### {#parse-integrity-policy-headers-section}
-  To <dfn>parse Integrity-Policy headers</dfn>, given a <a>Response</a> |response|
+  To <dfn>parse Integrity-Policy headers</dfn>, given a <a for=/>Response</a> |response|
   and a <a>policy container</a> |container|, do the following:
 
-  1. Let |headers| be |response|'s <a>header list</a>.
+  1. Let |headers| be |response|'s <a for=response>header list</a>.
   1. If |headers| <a for="header list">contains</a> a <a>header</a>
-     whose <a>header name</a> is "Integrity-Policy",
+     whose <a>header name</a> is "`Integrity-Policy`",
      let |container|'s <a>integrity policy</a> be the result of running
      <a>processing an integrity policy</a> with the corresponding <a>header value</a>.
   1. If |headers| <a for="header list">contains</a> a <a>header</a>
-     whose <a>header name</a> is "Integrity-Policy-Report-Only",
+     whose <a>header name</a> is "`Integrity-Policy-Report-Only`",
      let |container|'s <a>report only integrity policy</a> be the result of running
      <a>processing an integrity policy</a> with the corresponding <a>header value</a>.
   
   ### Should request be blocked by Integrity Policy ### {#should-request-be-blocked-by-integrity-policy-section}
-  To determine <dfn>should request be blocked by integrity policy</dfn>, given a <a>request</a> |request|,
+  To determine <dfn>should request be blocked by integrity policy</dfn>, given a <a for=/>request</a> |request|,
   do the following:
 
   1. Let |policy container| be |request|'s <a>policy container</a>.
@@ -581,11 +578,11 @@ spec:csp3; type:grammar; text:base64-value
   1. if |global| is not a <a>Window</a> nor a <a>WorkerGlobalScope</a>, return "Allowed".
   1. Let |block| be a boolean, initially false.
   1. Let |report block| be a boolean, initially false.
-  1. if |policy|'s <a>sources</a> <a for=list>contains</a> "inline"
+  1. if |policy|'s <a>sources</a> <a for=list>contains</a> "`inline`"
      and |policy|'s <a>blocked destinations</a> <a for=list>contains</a>
      |request|'s <a for=request>destination</a>,
      set |block| to true.
-  1. if |policy|'s <a>sources</a> <a for=list>contains</a> "inline"
+  1. if |policy|'s <a>sources</a> <a for=list>contains</a> "`inline`"
      and |report policy|'s <a>blocked destinations</a> <a for=list>contains</a>
      |request|'s <a for=request>destination</a>,
      set |report block| to true.
@@ -606,7 +603,7 @@ spec:csp3; type:grammar; text:base64-value
     };
   </pre>
 
-  To <dfn>report violation</dfn> given a <a>Request</a> |request|, a boolean |block|,
+  To <dfn>report violation</dfn> given a <a for=/>Request</a> |request|, a boolean |block|,
   a boolean |report block|, an <a>integrity policy struct</a> |policy|,
   and an <a>integrity policy struct</a> |report policy|, do the following:
 
@@ -614,10 +611,11 @@ spec:csp3; type:grammar; text:base64-value
   1. Let |settings object| be |request|'s <a for=request>client</a>.
   1. Let |global| be |settings object|'s <a>global object</a>.
   1. Assert that |global| is a <a>Window</a> or a <a>WorkerGlobalScope</a>.
-  1. Let |URL| be an empty <a for=/>URL</a>.
-  1. If |global| is a <a>Window</a>, set |URL| to |global|'s <a>associated Document</a> <a>document URL</a>.
-  1. If |global| is a <a>WorkerGlobalScope</a>, set |URL| to |global|'s <a for=WorkerGlobalScope>URL</a>.
-  1. Let |document URL| be the result of <a>strip URL for use in reports</a> on |URL|.
+  1. Let |url| be a <a for=/>URL</a>, initially null.
+  1. If |global| is a <a>Window</a>, set |url| to |global|'s <a>associated Document</a> <a>document URL</a>.
+  1. If |global| is a <a>WorkerGlobalScope</a>, set |url| to |global|'s <a for=WorkerGlobalScope>URL</a>.
+  1. Assert that |url| is a non-null <a for=/>URL</a>.
+  1. Let |document URL| be the result of <a>strip URL for use in reports</a> on |url|.
   1. Let |blocked URL| be the result of <a>strip URL for use in reports</a> on |request|'s <a for=request>URL</a>.
   1. If |block|, <a for=list>for each</a> |endpoint| in |policy|'s <a>endpoints</a>:
      1. Let |body| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:

--- a/index.bs
+++ b/index.bs
@@ -613,13 +613,13 @@ spec:csp3; type:grammar; text:base64-value
                  :   {{IntegrityPolicyViolationReportBody/reportOnly}}
                  ::  false
      2. <a>Generate and queue a report</a> with the following arguments:
-              :   <var ignore>context</var>
+              :   <a for="generate and queue a report"><i>context</i></a>
               ::  |settingsObject|
-              :   <var ignore>type</var>
+              :   <a for="generate and queue a report"><i>type</i></a>
               ::  "`integrity-policy-violation`"
-              :   <var ignore>destination</var>
+              :   <a for="generate and queue a report"><i>destination</i></a>
               ::  |endpoint|
-              :   <var ignore>data</var>
+              :   <a for="generate and queue a report"><i>data</i></a>
               ::  |body|
   1. If |reportBlock| is true, <a for=list>for each</a> |endpoint| in |reportPolicy|'s <a>endpoints</a>:
      1. Let |reportBody| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:
@@ -632,13 +632,13 @@ spec:csp3; type:grammar; text:base64-value
                  :   {{IntegrityPolicyViolationReportBody/reportOnly}}
                  ::  true 
      2. <a>Generate and queue a report</a> with the following arguments:
-              :   <var ignore>context</var>
+              :   <a for="generate and queue a report"><i>context</i></a>
               ::  |settingsObject|
-              :   <var ignore>type</var>
+              :   <a for="generate and queue a report"><i>type</i></a>
               ::  "`integrity-policy-violation`"
-              :   <var ignore>destination</var>
+              :   <a for="generate and queue a report"><i>destination</i></a>
               ::  |endpoint|
-              :   <var ignore>data</var>
+              :   <a for="generate and queue a report"><i>data</i></a>
               ::  |reportBody|
 
   ### Integration ### {#integration}

--- a/index.bs
+++ b/index.bs
@@ -581,42 +581,77 @@ spec:csp3; type:grammar; text:base64-value
   1. if |report policy|'s <a>enforcement</a> is "block" and |report policy|'s <a>source</a> is "inline"
      and |report policy|'s <a>destination</a> is equal to |request|'s <a for=request>destination</a>, set
     |report block| to true.
-  1. If |block| or |report block|, <a>fire a violation event</a> with |request|.
-  1. If |block|, <a>report violation</a> with |policy|'s <a>endpoints</a>.
-  1. If |report block|, <a>report violation</a> with |report policy|'s <a>endpoints</a>.
+  1. If |block| or |report block|, <a>report violation</a> with |request|, |block|, |report block|,
+     |policy| and |report policy|.
   1. If |block|, return "Blocked". Otherwise, return "Allowed".
  
-  ### Fire a violation event ### {#fire-violation-event}
+  ### Report violations ### {#report-violations}
 
   <pre class="idl">
 
     [Exposed=(Window,Worker)]
     interface IntegrityPolicyViolationEvent : Event {
         constructor(DOMString type, optional IntegrityPolicyViolationEventInit eventInitDict = {});
-        readonly    attribute USVString      documentURI;
-        readonly    attribute USVString      blockedURI;
+        readonly    attribute USVString      documentURL;
+        readonly    attribute USVString      blockedURL;
     };
     dictionary IntegrityPolicyViolationEventInit : EventInit {
-        USVString      documentURI = "";
-        USVString      blockedURI = "";
+        USVString      documentURL = "";
+        USVString      blockedURL = "";
     };
   </pre>
 
-  To <dfn>fire a violation event</dfn> given a <a>Request</a> |request|, do the following:
+  <pre class="idl">
+    [Exposed=Window]
+    interface IntegrityPolicyViolationReportBody : ReportBody {
+      [Default] object toJSON();
+      readonly attribute USVString documentURL;
+      readonly attribute USVString? blockedURL;
+    };
+  </pre>
+
+  To <dfn>report violation</dfn> given a <a>Request</a> |request|, a boolean |block|,
+  a boolean |report block|, an <a>integrity policy struct</a> |policy|,
+  and an <a>integrity policy struct</a> |report policy|, do the following:
 
   1. Assert that |request|'s <a for=request>client</a> is not null.
-  1. Let |global| be |request|'s <a for=request>client</a>'s <a>global object</a>.
+  1. Let |settings object| be |request|'s <a for=request>client</a>.
+  1. Let |global| be |settings object|'s <a>global object</a>.
   1. Assert that |global| is a <a>Window</a>.
   1. Let |target| be |global|'s <a>associated Document</a>.
-  1. Let |documentURI| be the result of <a>strip URL for use in reports</a> on |target|'s <a>document URL</a>.
-  1. Let |blockedURI| be the result of <a>strip URL for use in reports</a> on |request|'s <a for=request>URL</a>.
+  1. Let |document URL| be the result of <a>strip URL for use in reports</a> on |target|'s <a>document URL</a>.
+  1. Let |blocked URL| be the result of <a>strip URL for use in reports</a> on |request|'s <a for=request>URL</a>.
   1. <a>Fire an event</a> names "integritypolicyviolation" that uses the `IntegrityPolicyViolationEvent`
-     interface at |target|, with its attributes initiaized to |documentURI| and |blockedURI|.
-
-  ### Report violation ### {#report-violation-section}
-  To <dfn>report violation</dfn> given a <a>list</a> |endpoints|, do the following:
-
-  1. TODO do something with |endpoints|
+     interface at |target|, with its attributes initiaized as follows:
+              :   {{IntegrityPolicyViolationEvent/documentURL}}
+              ::  |document URL|
+              :   {{IntegrityPolicyViolationEvent/blockedURL}}
+              ::  |blocked URL|
+  1. Let |body| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:
+              :   {{IntegrityPolicyViolationReportBody/documentURL}}
+              ::  |document URL|
+              :   {{IntegrityPolicyViolationReportBody/blockedURL}}
+              ::  |blocked URL|
+  1. If |block|, <a for=list>for each</a> |endpoint| in |policy|'s <a>endpoints</a>,
+     <a>generate and queue a report</a> with the following arguments:
+              :   <var ignore>context</var>
+              ::  |settings object|
+              :   <var ignore>type</var>
+              ::  "integrity-policy-violation"
+              :   <var ignore>destination</var>
+              ::  |endpoint|
+              :   <var ignore>data</var>
+              ::  |body|
+  1. If |report block|, <a for=list>for each</a> |endpoint| in |report policy|'s <a>endpoints</a>,
+     <a>generate and queue a report</a> with the following arguments:
+              :   <var ignore>context</var>
+              ::  |settings object|
+              :   <var ignore>type</var>
+              ::  "integrity-policy-violation"
+              :   <var ignore>destination</var>
+              ::  |endpoint|
+              :   <var ignore>data</var>
+              ::  |body|
 
   ### Integration ### {#integration}
 

--- a/index.bs
+++ b/index.bs
@@ -32,6 +32,14 @@ spec: ABNF; urlPrefix: https://tools.ietf.org/html/rfc5234
     text: VCHAR; url: appendix-B.1
     text: WSP; url: appendix-B.1
 
+spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/
+  type: dfn
+    text: strip url for use in reports; url: strip-url-for-use-in-reports
+
+spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
+  type: dfn
+    text: document url; url: concept-document-url
+
 spec: INFRA; urlPrefix: https://infra.spec.whatwg.org
   type: dfn
     text: list; url: list
@@ -39,6 +47,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/C
   type: dfn
     text: policy container; url: policy-container
+    text: global object; url: global-object
+    text: window; url: window
 
 spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
@@ -571,15 +581,37 @@ spec:csp3; type:grammar; text:base64-value
   1. if |report policy|'s <a>enforcement</a> is "block" and |report policy|'s <a>source</a> is "inline"
      and |report policy|'s <a>destination</a> is equal to |request|'s <a for=request>destination</a>, set
     |report block| to true.
-  1. If |block| or |report block|, <a>fire a violation event</a>.
+  1. If |block| or |report block|, <a>fire a violation event</a> with |request|.
   1. If |block|, <a>report violation</a> with |policy|'s <a>endpoints</a>.
   1. If |report block|, <a>report violation</a> with |report policy|'s <a>endpoints</a>.
   1. If |block|, return "Blocked". Otherwise, return "Allowed".
  
   ### Fire a violation event ### {#fire-violation-event}
-  To <dfn>fire a violation event</dfn>, do the following:
 
-  1. TODO
+  <pre class="idl">
+
+    [Exposed=(Window,Worker)]
+    interface IntegrityPolicyViolationEvent : Event {
+        constructor(DOMString type, optional IntegrityPolicyViolationEventInit eventInitDict = {});
+        readonly    attribute USVString      documentURI;
+        readonly    attribute USVString      blockedURI;
+    };
+    dictionary IntegrityPolicyViolationEventInit : EventInit {
+        USVString      documentURI = "";
+        USVString      blockedURI = "";
+    };
+  </pre>
+
+  To <dfn>fire a violation event</dfn> given a <a>Request</a> |request|, do the following:
+
+  1. Assert that |request|'s <a for=request>client</a> is not null.
+  1. Let |global| be |request|'s <a for=request>client</a>'s <a>global object</a>.
+  1. Assert that |global| is a <a>Window</a>.
+  1. Let |target| be |global|'s <a>associated Document</a>.
+  1. Let |documentURI| be the result of <a>strip URL for use in reports</a> on |target|'s <a>document URL</a>.
+  1. Let |blockedURI| be the result of <a>strip URL for use in reports</a> on |request|'s <a for=request>URL</a>.
+  1. <a>Fire an event</a> names "integritypolicyviolation" that uses the `IntegrityPolicyViolationEvent`
+     interface at |target|, with its attributes initiaized to |documentURI| and |blockedURI|.
 
   ### Report violation ### {#report-violation-section}
   To <dfn>report violation</dfn> given a <a>list</a> |endpoints|, do the following:

--- a/index.bs
+++ b/index.bs
@@ -512,7 +512,7 @@ spec:csp3; type:grammar; text:base64-value
   
   A <dfn>source</dfn> is a string. The only possible value for it is "`inline`".
 
-  A <dfn>destination</dfn> is a <a for=request>destination</a>. The only possible value for it is "`script`".
+  A <dfn>destination</dfn> is a string. The only possible value for it is "`script`".
 
   An <dfn>integrity policy struct</dfn>, is a <a>struct</a> that contains the following:
 
@@ -520,20 +520,21 @@ spec:csp3; type:grammar; text:base64-value
     * <dfn>blocked destinations</dfn>, a list of <a>destination</a>s, initially empty.
     * <dfn>endpoints</dfn>, a <a for=/>list</a> of strings, initially empty.
 
-  When <dfn>processing an integrity policy</dfn>, with |headers| and |header name|, do the following:
+  When <dfn>processing an integrity policy</dfn>, with a <a for=/>header list</a> |headers|
+  and a <a>header name</a> |headerName|, do the following:
 
-  1. Let |integrity policy| be a new <a>integrity policy struct</a>.
+  1. Let |integrityPolicy| be a new <a>integrity policy struct</a>.
   1. Let |dictionary| be the result of <a>getting a structured field value</a> from |headers|
-     given |header name| and "`dictionary`".
+     given |headerName| and "`dictionary`".
   1. If |dictionary|["`sources`"] does not <a for=list>exist</a> or if its value
      <a for=list>contains</a> "`inline`", <a for=list>append</a> "`inline`" to
-     |integrity policy|'s <a>sources</a>.
+     |integrityPolicy|'s <a>sources</a>.
   1. If |dictionary|["`blocked-destinations`"] <a for=list>exists</a>:
     1. If its value <a for=list>contains</a> "`script`",
-       <a for=list>append</a> "`script`" to |integrity policy|'s <a>blocked destinations</a>.
+       <a for=list>append</a> "`script`" to |integrityPolicy|'s <a>blocked destinations</a>.
   1. If |dictionary|["`endpoints`"] <a for=map>exists</a>:
-    1. Set |integrity policy|'s <a>endpoints</a> to |dictionary|['endpoints'].
-  1. Return |integrity policy|.
+    1. Set |integrityPolicy|'s <a>endpoints</a> to |dictionary|['endpoints'].
+  1. Return |integrityPolicy|.
   
   ### Parse Integrity-Policy headers ### {#parse-integrity-policy-headers-section}
   To <dfn>parse Integrity-Policy headers</dfn>, given a <a for=/>Response</a> |response|
@@ -541,11 +542,13 @@ spec:csp3; type:grammar; text:base64-value
 
   1. Let |headers| be |response|'s <a for=response>header list</a>.
   1. If |headers| <a for="header list">contains</a> a <a>header</a>
-     whose <a>header name</a> is "`Integrity-Policy`",
+     whose <a>byte-lowercased</a> <a>header name</a>'s <a>isomorphic decode</a>
+     is "`integrity-policy`",
      set |container|'s <a>integrity policy</a> be the result of running
      <a>processing an integrity policy</a> with the corresponding <a>header value</a>.
   1. If |headers| <a for="header list">contains</a> a <a>header</a>
-     whose <a>header name</a> is "`Integrity-Policy-Report-Only`",
+     whose <a>byte-lowercased</a> <a>header name</a>'s <a>isomorphic decode</a>
+     is "`integrity-policy-report-only`",
      set |container|'s <a>report only integrity policy</a> be the result of running
      <a>processing an integrity policy</a> with the corresponding <a>header value</a>.
   
@@ -553,28 +556,28 @@ spec:csp3; type:grammar; text:base64-value
   To determine <dfn>should request be blocked by integrity policy</dfn>, given a <a for=/>request</a> |request|,
   do the following:
 
-  1. Let |policy container| be |request|'s <a for=request>policy container</a>.
+  1. Let |policyContainer| be |request|'s <a for=request>policy container</a>.
   1. If |request|'s <a>integrity metadata</a> is not the empty string
-     and |request|'s <a for=request>mode</a> is either "cors" or "same-origin",
+     and |request|'s <a for=request>mode</a> is either "`cors`" or "`same-origin`",
      return "Allowed".
-  1. Let |policy| be |policy container|'s <a>integrity policy</a>.
-  1. Let |report policy| be |policy container|'s <a>report only integrity policy</a>.
-  1. If both |policy| and |report policy| are empty <a>integrity policy struct</a>s, return "Allowed".
+  1. Let |policy| be |policyContainer|'s <a>integrity policy</a>.
+  1. Let |reportPolicy| be |policyContainer|'s <a>report only integrity policy</a>.
+  1. If both |policy| and |reportPolicy| are empty <a>integrity policy struct</a>s, return "Allowed".
   1. Let |global| be |request|'s <a for=request>client</a>'s <a for="environment settings object">global object</a>.
-  1. If |global| is not a {{Window}} nor a {{WorkerGlobalScope}}, return "Allowed".
+  1. If |global| is not a {{Window}} nor a {{WorkerGlobalScope}}, return "`Allowed`".
   1. Let |block| be a boolean, initially false.
-  1. Let |report block| be a boolean, initially false.
+  1. Let |reportBlock| be a boolean, initially false.
   1. If |policy|'s <a>sources</a> <a for=list>contains</a> "`inline`"
      and |policy|'s <a>blocked destinations</a> <a for=list>contains</a>
      |request|'s <a for=request>destination</a>,
      set |block| to true.
   1. If |policy|'s <a>sources</a> <a for=list>contains</a> "`inline`"
-     and |report policy|'s <a>blocked destinations</a> <a for=list>contains</a>
+     and |reportPolicy|'s <a>blocked destinations</a> <a for=list>contains</a>
      |request|'s <a for=request>destination</a>,
-     set |report block| to true.
-  1. If |block| or |report block|, <a>report violation</a> with |request|, |block|, |report block|,
-     |policy| and |report policy|.
-  1. If |block|, return "Blocked". Otherwise, return "Allowed".
+     set |reportBlock| to true.
+  1. If |block| is true or |reportBlock| is true, then <a>report violation</a>
+     with |request|, |block|, |reportBlock|, |policy| and |reportPolicy|.
+  1. If |block| is true, then return "`Blocked`"; otherwise "`Allowed`".
  
   ### Report violations ### {#report-violations}
 
@@ -590,57 +593,57 @@ spec:csp3; type:grammar; text:base64-value
   </pre>
 
   To <dfn>report violation</dfn> given a <a for=/>Request</a> |request|, a boolean |block|,
-  a boolean |report block|, an <a>integrity policy struct</a> |policy|,
-  and an <a>integrity policy struct</a> |report policy|, do the following:
+  a boolean |reportBlock|, an <a>integrity policy struct</a> |policy|,
+  and an <a>integrity policy struct</a> |reportPolicy|, do the following:
 
   1. <a>Assert</a>: |request|'s <a for=request>client</a> is not null.
-  1. Let |settings object| be |request|'s <a for=request>client</a>.
-  1. Let |global| be |settings object|'s <a for="environment settings object">global object</a>.
+  1. Let |settingsObject| be |request|'s <a for=request>client</a>.
+  1. Let |global| be |settingsObject|'s <a for="environment settings object">global object</a>.
   1. <a>Assert</a>: |global| is a {{Window}} or a {{WorkerGlobalScope}}.
   1. Let |url| be null.
   1. If |global| is a {{Window}}, set |url| to |global|'s <a>associated Document</a>'s {{Document/URL}}.
   1. If |global| is a {{WorkerGlobalScope}}, set |url| to |global|'s <a for=WorkerGlobalScope>URL</a>.
-  1. <a>Assert</a>: |url| a <a for=/>URL</a>.
-  1. Let |document URL| be the result of <a>strip URL for use in reports</a> on |url|.
-  1. Let |blocked URL| be the result of <a>strip URL for use in reports</a> on |request|'s <a for=request>URL</a>.
+  1. <a>Assert</a>: |url| is a <a for=/>URL</a>.
+  1. Let |documentURL| be the result of <a>strip URL for use in reports</a> on |url|.
+  1. Let |blockedURL| be the result of <a>strip URL for use in reports</a> on |request|'s <a for=request>URL</a>.
   1. If |block|, <a for=list>for each</a> |endpoint| in |policy|'s <a>endpoints</a>:
      1. Let |body| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:
                  :   {{IntegrityPolicyViolationReportBody/documentURL}}
-                 ::  |document URL|
+                 ::  |documentURL|
                  :   {{IntegrityPolicyViolationReportBody/blockedURL}}
-                 ::  |blocked URL|
+                 ::  |blockedURL|
                  :   {{IntegrityPolicyViolationReportBody/destination}}
                  ::  |request|'s <a for=request>destination</a>
                  :   {{IntegrityPolicyViolationReportBody/reportOnly}}
                  ::  false
      2. <a>Generate and queue a report</a> with the following arguments:
               :   <var ignore>context</var>
-              ::  |settings object|
+              ::  |settingsObject|
               :   <var ignore>type</var>
-              ::  "integrity-policy-violation"
+              ::  "`integrity-policy-violation`"
               :   <var ignore>destination</var>
               ::  |endpoint|
               :   <var ignore>data</var>
               ::  |body|
-  1. If |report block|, <a for=list>for each</a> |endpoint| in |policy|'s <a>endpoints</a>:
-     1. Let |report body| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:
+  1. If |reportBlock|, <a for=list>for each</a> |endpoint| in |reportPolicy|'s <a>endpoints</a>:
+     1. Let |reportBody| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:
                  :   {{IntegrityPolicyViolationReportBody/documentURL}}
-                 ::  |document URL|
+                 ::  |documentURL|
                  :   {{IntegrityPolicyViolationReportBody/blockedURL}}
-                 ::  |blocked URL|
+                 ::  |blockedURL|
                  :   {{IntegrityPolicyViolationReportBody/destination}}
                  ::  |request|'s <a for=request>destination</a>
                  :   {{IntegrityPolicyViolationReportBody/reportOnly}}
                  ::  true 
      2. <a>Generate and queue a report</a> with the following arguments:
               :   <var ignore>context</var>
-              ::  |settings object|
+              ::  |settingsObject|
               :   <var ignore>type</var>
-              ::  "integrity-policy-violation"
+              ::  "`integrity-policy-violation`"
               :   <var ignore>destination</var>
               ::  |endpoint|
               :   <var ignore>data</var>
-              ::  |report body|
+              ::  |reportBody|
 
   ### Integration ### {#integration}
 
@@ -653,7 +656,7 @@ spec:csp3; type:grammar; text:base64-value
   <a>parse Integrity-Policy headers</a> with <var ignore>response</var> and <var ignore>result</var>.
 
   Expand step 7 of <a>main fetch</a> to call <a>should request be blocked by integrity policy</a>
-  and return a <a>network error</a> if it returns "blocked"
+  and return a <a>network error</a> if it returns "`Blocked`".
 
   # Proxies # {#proxies}
 

--- a/index.bs
+++ b/index.bs
@@ -556,12 +556,14 @@ spec:csp3; type:grammar; text:base64-value
   and a <a>policy container</a> |container|, do the following:
 
   1. Let |headers| be |response|'s <a>header list</a>.
-  1. If |headers| <a for="header list">contains</a> a <a>header</a> whose <a>header name</a> is "Integrity-Policy",
-     let |container|'s <a>integrity policy</a> be the result of running <a>processing an integrity policy</a>
-     with the corresponding <a>header value</a>.
-  1. If |headers| <a for="header list">contains</a> a <a>header</a> whose <a>header name</a> is "Integrity-Policy-Report-Only",
-     let |container|'s <a>report only integrity policy</a> be the result of running <a>processing an integrity
-     policy</a> with the corresponding <a>header value</a>.
+  1. If |headers| <a for="header list">contains</a> a <a>header</a>
+     whose <a>header name</a> is "Integrity-Policy",
+     let |container|'s <a>integrity policy</a> be the result of running
+     <a>processing an integrity policy</a> with the corresponding <a>header value</a>.
+  1. If |headers| <a for="header list">contains</a> a <a>header</a>
+     whose <a>header name</a> is "Integrity-Policy-Report-Only",
+     let |container|'s <a>report only integrity policy</a> be the result of running
+     <a>processing an integrity policy</a> with the corresponding <a>header value</a>.
   
   ### Should request be blocked by Integrity Policy ### {#should-request-be-blocked-by-integrity-policy-section}
   To determine <dfn>should request be blocked by integrity policy</dfn>, given a <a>request</a> |request|,
@@ -575,11 +577,13 @@ spec:csp3; type:grammar; text:base64-value
   1. Let |report policy| be |policy container|'s <a>report only integrity policy</a>.
   1. Let |block| be a boolean, initially false.
   1. Let |report block| be a boolean, initially false.
-  1. if |policy|'s <a>source</a> is "inline"
-     and |policy|'s <a>blocked destinations</a> <a for=list>contains</a> |request|'s <a for=request>destination</a>,
+  1. if |policy|'s <a>sources</a> <a for=list>contains</a> "inline"
+     and |policy|'s <a>blocked destinations</a> <a for=list>contains</a>
+     |request|'s <a for=request>destination</a>,
      set |block| to true.
-  1. if |report policy|'s <a>source</a> is "inline"
-     and |report policy|'s <a>blocked destinations</a> <a for=list>contains</a> |request|'s <a for=request>destination</a>,
+  1. if |policy|'s <a>sources</a> <a for=list>contains</a> "inline"
+     and |report policy|'s <a>blocked destinations</a> <a for=list>contains</a>
+     |request|'s <a for=request>destination</a>,
      set |report block| to true.
   1. If |block| or |report block|, <a>report violation</a> with |request|, |block|, |report block|,
      |policy| and |report policy|.

--- a/index.bs
+++ b/index.bs
@@ -519,68 +519,77 @@ spec:csp3; type:grammar; text:base64-value
   The headers' value is a <a>Dictionary</a> [[RFC9651]], with every member-value being an
   <a>inner list</a> of <a>tokens</a>.
   
+  A <dfn>source</dfn> is a string. The only possible value for it is "inline".
+  A <dfn>destination</dfn> is a string. The only possible value for it is "script".
+
   An <dfn>integrity policy struct</dfn>, is a <a>struct</a> that contains the following:
+
     * <dfn>enforcement</dfn>, a string which is the empty string or "block". Initially "block".
-    * <dfn>source</dfn>, a string which is the empty string or "inline". Initially "inline".
-    * <dfn>destination</dfn>, a string which is the empty string or "script". Initially the empty string.
+    * <dfn>sources</dfn>, a list of <a>source</a>s, Initially empty.
+    * <dfn>destinations</dfn>, a list of <a>destination</a>s, Initially empty.
     * <dfn>endpoints</dfn>, a <a>list</a> of strings, initially empty.
 
   When <dfn>processing an integrity policy</dfn>, with |input|, do the following:
-  1) Let |integrity policy| be a new <a>integrity policy struct</a>.
-  1) Let |dictionary| be the result of <a>parsing a dictionary</a> with |input|.
-  1) If |dictionary|['enforcement'] exists:
-    1) If its value is "block", set |integrity policy|'s <a>enforcement</a> to "block".
-    1) Otherwise, set |integrity policy|'s <a>enforcement</a> to the empty string.
-  1) If |dictionary|['sources'] exists:
-    1) If its value <a>contains</a> "inline", set |integrity policy|'s <a>source</a> to "inline".
-    1) Otherwise, set |integrity policy|'s <a>source</a> to the empty string.
-  1) If |dictionary|['destinations'] exists:
-    1) If its value <a>contains</a> "script", set |integrity policy|'s <a>destination</a> to "script".
-  1) if |dictionary|['endpoints'] exists:
-    1) Set |integrity policy|'s <a>endpoints</a> to |dictionary|['endpoints'].
-  1) return |integrity policy|
+
+  1. Let |integrity policy| be a new <a>integrity policy struct</a>.
+  1. Let |dictionary| be the result of <a>parsing a dictionary</a> with |input|.
+  1. If |dictionary|['enforcement'] exists:
+    1. If its value is "block", set |integrity policy|'s <a>enforcement</a> to "block".
+    1. Otherwise, set |integrity policy|'s <a>enforcement</a> to the empty string.
+  1. If |dictionary|['sources'] does not exist or if its value does not <a for=list>contain</a> "inline",
+     <a for=list>append</a> "inline" to |integrity policy|'s <a>sources</a>.
+  1. If |dictionary|['destinations'] exists:
+    1. If its value <a for=list>contains</a> "script", set |integrity policy|'s <a>destinations</a> to "script".
+  1. if |dictionary|['endpoints'] exists:
+    1. Set |integrity policy|'s <a>endpoints</a> to |dictionary|['endpoints'].
+  1. return |integrity policy|
   
   ### Parse Integrity-Policy headers ### {#parse-integrity-policy-headers-section}
   To <dfn>parse Integrity-Policy headers</dfn>, given a <a>Response</a> |response|
   and a <a>policy container</a> |container|, do the following:
-  1) Let |headers| be |response|'s <a>header list</a>.
-  1) If |headers| <a>contains</a> a <a>header</a> whose <a>header name</a> is "Integrity-Policy",
+
+  1. Let |headers| be |response|'s <a>header list</a>.
+  1. If |headers| <a for="header list">contains</a> a <a>header</a> whose <a>header name</a> is "Integrity-Policy",
      let |container|'s <a>integrity policy</a> be the result of running <a>processing an integrity policy</a>
      with the corresponding <a>header value</a>.
-  1) If |headers| <a>contains</a> a <a>header</a> whose <a>header name</a> is "Integrity-Policy-Report-Only",
+  1. If |headers| <a for="header list">contains</a> a <a>header</a> whose <a>header name</a> is "Integrity-Policy-Report-Only",
      let |container|'s <a>report only integrity policy</a> be the result of running <a>processing an integrity
      policy</a> with the corresponding <a>header value</a>.
   
   ### Should request be blocked by Integrity Policy ### {#should-request-be-blocked-by-integrity-policy-section}
   To determine <dfn>should request be blocked by integrity policy</dfn>, given a <a>request</a> |request|,
   do the following:
-  1) Let |policy container| be |request|'s <a>policy container</a>.
-  1) if |request|'s <a>integrity metadata</a> is not empty, return "Allowed".
-  1) Let |policy| be |policy container|'s <a>integrity policy</a>.
-  1) Let |report policy| be |policy container|'s <a>report only integrity policy</a>.
-  1) Let |block| be a boolean, initially false.
-  1) Let |report block| be a boolean, initially false.
-  1) if |policy|'s <a>enforcement</a> is "block" and |policy|'s <a>source</a> is "inline" and |policy|'s
+
+  1. Let |policy container| be |request|'s <a>policy container</a>.
+  1. if |request|'s <a>integrity metadata</a> is not empty, return "Allowed".
+  1. Let |policy| be |policy container|'s <a>integrity policy</a>.
+  1. Let |report policy| be |policy container|'s <a>report only integrity policy</a>.
+  1. Let |block| be a boolean, initially false.
+  1. Let |report block| be a boolean, initially false.
+  1. if |policy|'s <a>enforcement</a> is "block" and |policy|'s <a>source</a> is "inline" and |policy|'s
      <a>destination</a> is equal to |request|'s <a for=request>destination</a>, set |block| to true.
-  1) if |report policy|'s <a>enforcement</a> is "block" and |report policy|'s <a>source</a> is "inline"
+  1. if |report policy|'s <a>enforcement</a> is "block" and |report policy|'s <a>source</a> is "inline"
      and |report policy|'s <a>destination</a> is equal to |request|'s <a for=request>destination</a>, set
     |report block| to true.
-  1) If |block| or |report block|, <a>fire a violation event</a>.
-  1) If |block|, <a>report violation</a> with |policy|'s <a>endpoints</a>.
-  1) If |report block|, <a>report violation</a> with |report policy|'s <a>endpoints</a>.
-  1) If |block|, return "Blocked". Otherwise, return "Allowed".
+  1. If |block| or |report block|, <a>fire a violation event</a>.
+  1. If |block|, <a>report violation</a> with |policy|'s <a>endpoints</a>.
+  1. If |report block|, <a>report violation</a> with |report policy|'s <a>endpoints</a>.
+  1. If |block|, return "Blocked". Otherwise, return "Allowed".
  
   ### Fire a violation event ### {#fire-violation-event}
   To <dfn>fire a violation event</dfn>, do the following:
-  1) TODO
+
+  1. TODO
 
   ### Report violation ### {#report-violation-section}
   To <dfn>report violation</dfn> given a <a>list</a> |endpoints|, do the following:
-  1) TODO do something with |endpoints|
+
+  1. TODO do something with |endpoints|
 
   ### Integration ### {#integration}
 
   A <a>policy container</a> has extra items:
+
   * <dfn>integrity policy</dfn>, an <a>integrity policy struct</a>.
   * <dfn>report only integrity policy</dfn>, an <a>integrity policy struct</a>.
 

--- a/index.bs
+++ b/index.bs
@@ -44,9 +44,17 @@ spec: SHA2; urlPrefix: https://csrc.nist.gov/publications/fips/fips180-4/fips-18
     text: SHA-256; url: #
     text: SHA-384; url: #
     text: SHA-512; url: #
+
 spec: RFC8288; urlPrefix: https://tools.ietf.org/html/rfc8288
   type: http-header
     text: link
+
+spec RFC9651; urlPrefix: https://tools.ietf.org/html/rfc9651
+  type: dfn
+    text: Dictionary; url: name-dictionaries
+    text: inner list; url: name-inner-lists
+    text: token; url: name-tokens
+
 </pre>
 <pre class="link-defaults">
 spec:csp3; type:grammar; text:base64-value
@@ -485,6 +493,15 @@ spec:csp3; type:grammar; text:base64-value
   failed resource with a different one.
 
   <!-- ####################################################################### -->
+  
+  ## Integrity-Policy ## {#integrity-policy}
+  The `Integrity-Policy` HTTP header enables a document to enforce a policy regarding
+  the integrity metadata requirements on all the subresources it loads of certain
+  destinations.
+
+  It is a <a>Dictionary</a> [[RFC9651]], with every member-value being an
+  <a>inner list</a> of <a>tokens</a>.
+  
 
   # Proxies # {#proxies}
 

--- a/index.bs
+++ b/index.bs
@@ -49,6 +49,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/C
     text: policy container; url: policy-container
     text: global object; url: global-object
     text: window; url: window
+    text: WorkerGlobalScope; url: workerglobalscope
 
 spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
@@ -576,7 +577,8 @@ spec:csp3; type:grammar; text:base64-value
   1. Let |policy| be |policy container|'s <a>integrity policy</a>.
   1. Let |report policy| be |policy container|'s <a>report only integrity policy</a>.
   1. If both |policy| and |report policy| are empty <a>integrity policy struct</a>s, return "Allowed".
-  1. Assert that |request|'s <a for=request>client</a>'s <a>global object</a> is a <a>Window</a>. 
+  1. Let |global| be |request|'s <a for=request>client</a>'s <a>global object</a>.
+  1. if |global| is not a <a>Window</a> nor a <a>WorkerGlobalScope</a>, return "Allowed".
   1. Let |block| be a boolean, initially false.
   1. Let |report block| be a boolean, initially false.
   1. if |policy|'s <a>sources</a> <a for=list>contains</a> "inline"
@@ -611,9 +613,11 @@ spec:csp3; type:grammar; text:base64-value
   1. Assert that |request|'s <a for=request>client</a> is not null.
   1. Let |settings object| be |request|'s <a for=request>client</a>.
   1. Let |global| be |settings object|'s <a>global object</a>.
-  1. Assert that |global| is a <a>Window</a>.
-  1. Let |target| be |global|'s <a>associated Document</a>.
-  1. Let |document URL| be the result of <a>strip URL for use in reports</a> on |target|'s <a>document URL</a>.
+  1. Assert that |global| is a <a>Window</a> or a <a>WorkerGlobalScope</a>.
+  1. Let |URL| be an empty <a for=/>URL</a>.
+  1. If |global| is a <a>Window</a>, set |URL| to |global|'s <a>associated Document</a> <a>document URL</a>.
+  1. If |global| is a <a>WorkerGlobalScope</a>, set |URL| to |global|'s <a for=WorkerGlobalScope>URL</a>.
+  1. Let |document URL| be the result of <a>strip URL for use in reports</a> on |URL|.
   1. Let |blocked URL| be the result of <a>strip URL for use in reports</a> on |request|'s <a for=request>URL</a>.
   1. If |block|, <a for=list>for each</a> |endpoint| in |policy|'s <a>endpoints</a>:
      1. Let |body| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:

--- a/index.bs
+++ b/index.bs
@@ -668,9 +668,6 @@ spec:csp3; type:grammar; text:base64-value
   Add an extra step to <a>create a policy container from a fetch response</a> before it returns, that runs
   <a>parse Integrity-Policy headers</a> with <var ignore>response</var> and <var ignore>result</var>.
 
-  Note: The creation of a policy container only happens on navigation responses, but there's no
-        current way to assert that as part of the algorithm.
-
   Expand step 7 of <a>main fetch</a> to call <a>should request be blocked by integrity policy</a>
   and return a <a>network error</a> if it returns "blocked"
 

--- a/index.bs
+++ b/index.bs
@@ -49,7 +49,7 @@ spec: RFC8288; urlPrefix: https://tools.ietf.org/html/rfc8288
   type: http-header
     text: link
 
-spec RFC9651; urlPrefix: https://tools.ietf.org/html/rfc9651
+spec: RFC9651; urlPrefix: https://tools.ietf.org/html/rfc9651
   type: dfn
     text: Dictionary; url: name-dictionaries
     text: inner list; url: name-inner-lists
@@ -495,13 +495,67 @@ spec:csp3; type:grammar; text:base64-value
   <!-- ####################################################################### -->
   
   ## Integrity-Policy ## {#integrity-policy}
-  The `Integrity-Policy` HTTP header enables a document to enforce a policy regarding
-  the integrity metadata requirements on all the subresources it loads of certain
-  destinations.
+  The `Integrity-Policy` and `Integrity-Policy-Report-Only` HTTP headers enable a document to
+  enforce a policy regarding the integrity metadata requirements on all the subresources it
+  loads of certain <a>destinations</a>.
 
-  It is a <a>Dictionary</a> [[RFC9651]], with every member-value being an
+  The headers' value is a <a>Dictionary</a> [[RFC9651]], with every member-value being an
   <a>inner list</a> of <a>tokens</a>.
   
+  An <dfn>integrity policy struct</dfn>, is a <a>struct</a> that contains the following:
+    * <dfn>enforcement</dfn>, a string which is the empty string or "block". Initially "block".
+    * <dfn>source</dfn>, a string which is the empty string or "inline". Initially "inline".
+    * <dfn>destination</dfn>, a string which is the empty string or "script". Initially the empty string.
+    * <dfn>endpoints</dfn>, a <a>list</a> of strings, initially empty.
+
+  When <dfn>processing an integrity policy</dfn>, with |value|, do the following:
+  1) Let |integrity policy| be a new <a>integrity policy struct</a>.
+  1) Let <var>dictionary</var> be the result of <a>parsing a dictionary</a> with |input|.
+  1) If dictionary['enforcement'] exists:
+    1) If its value is "block", set |integrity policy|'s |enforcement| to "block".
+    1) Otherwise, set |integrity policy|'s |enforcement| to the empty string.
+  1) If dictionary['sources'] exists:
+    1) If its value <a>contains</a> "inline", set |integrity policy|'s |source| to "inline".
+    1) Otherwise, set |integrity policy|'s |source| to the empty string.
+  1) If dictionary['destinations'] exists:
+    1) If its value <a>contains</a> "script", set |integrity policy|'s |destination| to "script".
+  1) if dictionary['endpoints'] exists:
+    1) Set |integrity policy|'s |endpoints| to dictionary['endpoints'].
+  1) return |integrity policy|
+  
+  Each <a>Document</a> has an <dfn>integrity policy</dfn>, an <a>integrity policy struct</a>.
+  Each <a>Document</a> has an <dfn>integrity policy report only</dfn>, an <a>integrity policy struct</a>.
+
+  ### Parse Integrity-Policy headers
+  Given a <a>response<a> |response| and a <a>Document</a> |document|, do the following:
+  1) Let |headers| be |response|'s <a>header list</a>.
+  1) If |headers| <a>contains</a> a <a>header</a> whose <a>header name</a> is "Integrity-Policy",
+     let |document|'s <a>integrity policy</a> be the result of running <a>processing an integrity policy</a>
+     with the corresponding <a>header value</a>.
+  1) If |headers| <a>contains</a> a <a>header</a> whose <a>header name</a> is "Integrity-Policy-Report-Only",
+     let |document|'s <a>integrity policy report only</a> be the result of running <a>processing an integrity
+     policy</a> with the corresponding <a>header value</a>.
+  
+  ### Should request be blocked by Integrity Policy ### {#should-request-be-blocked-by-integrity-policy}
+  Given a <a>request</a> |request| and a <a>Document</a> |document|, do the following:
+  1) if |request|'s <a>integrity metadata</a> is not empty, return false.
+  1) Let |policy| be |document|'s <a>integrity policy</a>.
+  1) Let |report policy| be |document|'s <a>integrity policy report only</a>.
+  1) Let |block| be a boolean, initially false.
+  1) Let |report block| be a boolean, initially false.
+  1) if |policy|'s <a>enforcement</a> is "block" and |policy|'s <a>source</a> is "inline" and |policy|'s
+     <a>destination</a> is equal to |request|'s <a for=request>destination</a>, set |block| to true.
+  1) if |report policy|'s <a>enforcement</a> is "block" and |report policy|'s <a>source</a> is "inline"
+     and |report policy|'s <a>destination</a> is equal to |request|'s <a for=request>destination</a>, set
+    |report block| to true.
+  1) If |block| or |report block|, <a>fire a violation event</a>.
+  1) If |block|, <a>report violation</a> with |policy|'s <a>endpoints</a>.
+  1) If |report block|, <a>report violation</a> with |report policy|'s <a>endpoints</a>.
+ 
+  ### Fire a violation event ### {#fire-violation-event}
+  ### Report violatoin ### {#report-violation}
+
+  ### Fetch integration ### {#fetch-integration}
 
   # Proxies # {#proxies}
 

--- a/index.bs
+++ b/index.bs
@@ -512,7 +512,7 @@ spec:csp3; type:grammar; text:base64-value
   
   A <dfn>source</dfn> is a string. The only possible value for it is "`inline`".
 
-  A <dfn>destination</dfn> is a string. The only possible value for it is "`script`".
+  A <dfn>destination</dfn> is a <a for=request>destination</a>. The only possible value for it is "`script`".
 
   An <dfn>integrity policy struct</dfn>, is a <a>struct</a> that contains the following:
 

--- a/index.bs
+++ b/index.bs
@@ -546,7 +546,7 @@ spec:csp3; type:grammar; text:base64-value
   1. If |dictionary|['enforcement'] exists:
     1. If its value is "block", set |integrity policy|'s <a>enforcement</a> to "block".
     1. Otherwise, set |integrity policy|'s <a>enforcement</a> to the empty string.
-  1. If |dictionary|['sources'] does not exist or if its value does not <a for=list>contain</a> "inline",
+  1. If |dictionary|['sources'] does not exist or if its value <a for=list>contains</a> "inline",
      <a for=list>append</a> "inline" to |integrity policy|'s <a>sources</a>.
   1. If |dictionary|['destinations'] exists:
     1. If its value <a for=list>contains</a> "script", set |integrity policy|'s <a>destinations</a> to "script".
@@ -588,25 +588,13 @@ spec:csp3; type:grammar; text:base64-value
   ### Report violations ### {#report-violations}
 
   <pre class="idl">
-
-    [Exposed=(Window,Worker)]
-    interface IntegrityPolicyViolationEvent : Event {
-        constructor(DOMString type, optional IntegrityPolicyViolationEventInit eventInitDict = {});
-        readonly    attribute USVString      documentURL;
-        readonly    attribute USVString      blockedURL;
-    };
-    dictionary IntegrityPolicyViolationEventInit : EventInit {
-        USVString      documentURL = "";
-        USVString      blockedURL = "";
-    };
-  </pre>
-
-  <pre class="idl">
     [Exposed=Window]
     interface IntegrityPolicyViolationReportBody : ReportBody {
       [Default] object toJSON();
       readonly attribute USVString documentURL;
-      readonly attribute USVString? blockedURL;
+      readonly attribute USVString blockedURL;
+      readonly attribute USVString destination;
+      readonly attribute boolean   reportOnly;
     };
   </pre>
 
@@ -621,19 +609,17 @@ spec:csp3; type:grammar; text:base64-value
   1. Let |target| be |global|'s <a>associated Document</a>.
   1. Let |document URL| be the result of <a>strip URL for use in reports</a> on |target|'s <a>document URL</a>.
   1. Let |blocked URL| be the result of <a>strip URL for use in reports</a> on |request|'s <a for=request>URL</a>.
-  1. <a>Fire an event</a> names "integritypolicyviolation" that uses the `IntegrityPolicyViolationEvent`
-     interface at |target|, with its attributes initiaized as follows:
-              :   {{IntegrityPolicyViolationEvent/documentURL}}
-              ::  |document URL|
-              :   {{IntegrityPolicyViolationEvent/blockedURL}}
-              ::  |blocked URL|
-  1. Let |body| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:
-              :   {{IntegrityPolicyViolationReportBody/documentURL}}
-              ::  |document URL|
-              :   {{IntegrityPolicyViolationReportBody/blockedURL}}
-              ::  |blocked URL|
-  1. If |block|, <a for=list>for each</a> |endpoint| in |policy|'s <a>endpoints</a>,
-     <a>generate and queue a report</a> with the following arguments:
+  1. If |block|, <a for=list>for each</a> |endpoint| in |policy|'s <a>endpoints</a>:
+     1. Let |body| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:
+                 :   {{IntegrityPolicyViolationReportBody/documentURL}}
+                 ::  |document URL|
+                 :   {{IntegrityPolicyViolationReportBody/blockedURL}}
+                 ::  |blocked URL|
+                 :   {{IntegrityPolicyViolationReportBody/destination}}
+                 ::  |request|'s <a for=request>destination</a>
+                 :   {{IntegrityPolicyViolationReportBody/reportOnly}}
+                 ::  false
+     2. <a>Generate and queue a report</a> with the following arguments:
               :   <var ignore>context</var>
               ::  |settings object|
               :   <var ignore>type</var>
@@ -642,8 +628,17 @@ spec:csp3; type:grammar; text:base64-value
               ::  |endpoint|
               :   <var ignore>data</var>
               ::  |body|
-  1. If |report block|, <a for=list>for each</a> |endpoint| in |report policy|'s <a>endpoints</a>,
-     <a>generate and queue a report</a> with the following arguments:
+  1. If |report block|, <a for=list>for each</a> |endpoint| in |policy|'s <a>endpoints</a>:
+     1. Let |report body| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:
+                 :   {{IntegrityPolicyViolationReportBody/documentURL}}
+                 ::  |document URL|
+                 :   {{IntegrityPolicyViolationReportBody/blockedURL}}
+                 ::  |blocked URL|
+                 :   {{IntegrityPolicyViolationReportBody/destination}}
+                 ::  |request|'s <a for=request>destination</a>
+                 :   {{IntegrityPolicyViolationReportBody/reportOnly}}
+                 ::  true 
+     2. <a>Generate and queue a report</a> with the following arguments:
               :   <var ignore>context</var>
               ::  |settings object|
               :   <var ignore>type</var>
@@ -651,7 +646,7 @@ spec:csp3; type:grammar; text:base64-value
               :   <var ignore>destination</var>
               ::  |endpoint|
               :   <var ignore>data</var>
-              ::  |body|
+              ::  |report body|
 
   ### Integration ### {#integration}
 

--- a/index.bs
+++ b/index.bs
@@ -36,21 +36,6 @@ spec: CSP; urlPrefix: https://www.w3.org/TR/CSP3/
   type: dfn
     text: strip url for use in reports; url: strip-url-for-use-in-reports
 
-spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
-  type: dfn
-    text: document url; url: concept-document-url
-
-spec: INFRA; urlPrefix: https://infra.spec.whatwg.org
-  type: dfn
-    text: list; url: list
-
-spec: HTML; urlPrefix: https://html.spec.whatwg.org/C
-  type: dfn
-    text: policy container; url: policy-container
-    text: global object; url: global-object
-    text: window; url: window
-    text: WorkerGlobalScope; url: workerglobalscope
-
 spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
     text: main fetch; url: main-fetch
@@ -531,58 +516,59 @@ spec:csp3; type:grammar; text:base64-value
 
   An <dfn>integrity policy struct</dfn>, is a <a>struct</a> that contains the following:
 
-    * <dfn>sources</dfn>, a list of <a>source</a>s, Initially empty.
-    * <dfn>blocked destinations</dfn>, a list of <a>destination</a>s, Initially empty.
-    * <dfn>endpoints</dfn>, a <a>list</a> of strings, initially empty.
+    * <dfn>sources</dfn>, a list of <a>source</a>s, initially empty.
+    * <dfn>blocked destinations</dfn>, a list of <a>destination</a>s, initially empty.
+    * <dfn>endpoints</dfn>, a <a for=/>list</a> of strings, initially empty.
 
   When <dfn>processing an integrity policy</dfn>, with |headers| and |header name|, do the following:
 
-  1. Let |integrityPolicy| be a new <a>integrity policy struct</a>.
+  1. Let |integrity policy| be a new <a>integrity policy struct</a>.
   1. Let |dictionary| be the result of <a>getting a structured field value</a> from |headers|
      given |header name| and "`dictionary`".
-  1. If |dictionary|["`sources`"] does not exist or if its value <a for=list>contains</a> "`inline`",
-     <a for=list>append</a> "`inline`" to |integrityPolicy|'s <a>sources</a>.
-  1. If |dictionary|["`blocked-destinations`"] exists:
+  1. If |dictionary|["`sources`"] does not <a for=list>exist</a> or if its value
+     <a for=list>contains</a> "`inline`", <a for=list>append</a> "`inline`" to
+     |integrity policy|'s <a>sources</a>.
+  1. If |dictionary|["`blocked-destinations`"] <a for=list>exists</a>:
     1. If its value <a for=list>contains</a> "`script`",
-       <a for=list>append</a> "`script`" to |integrityPolicy|'s <a>blocked destinations</a>.
+       <a for=list>append</a> "`script`" to |integrity policy|'s <a>blocked destinations</a>.
   1. If |dictionary|["`endpoints`"] <a for=map>exists</a>:
-    1. Set |integrityPolicy|'s <a>endpoints</a> to |dictionary|['endpoints'].
-  1. Return |integrityPolicy|.
+    1. Set |integrity policy|'s <a>endpoints</a> to |dictionary|['endpoints'].
+  1. Return |integrity policy|.
   
   ### Parse Integrity-Policy headers ### {#parse-integrity-policy-headers-section}
   To <dfn>parse Integrity-Policy headers</dfn>, given a <a for=/>Response</a> |response|
-  and a <a>policy container</a> |container|, do the following:
+  and a <a for=/>policy container</a> |container|, do the following:
 
   1. Let |headers| be |response|'s <a for=response>header list</a>.
   1. If |headers| <a for="header list">contains</a> a <a>header</a>
      whose <a>header name</a> is "`Integrity-Policy`",
-     let |container|'s <a>integrity policy</a> be the result of running
+     set |container|'s <a>integrity policy</a> be the result of running
      <a>processing an integrity policy</a> with the corresponding <a>header value</a>.
   1. If |headers| <a for="header list">contains</a> a <a>header</a>
      whose <a>header name</a> is "`Integrity-Policy-Report-Only`",
-     let |container|'s <a>report only integrity policy</a> be the result of running
+     set |container|'s <a>report only integrity policy</a> be the result of running
      <a>processing an integrity policy</a> with the corresponding <a>header value</a>.
   
   ### Should request be blocked by Integrity Policy ### {#should-request-be-blocked-by-integrity-policy-section}
   To determine <dfn>should request be blocked by integrity policy</dfn>, given a <a for=/>request</a> |request|,
   do the following:
 
-  1. Let |policy container| be |request|'s <a>policy container</a>.
-  1. if |request|'s <a>integrity metadata</a> is not the empty string
+  1. Let |policy container| be |request|'s <a for=request>policy container</a>.
+  1. If |request|'s <a>integrity metadata</a> is not the empty string
      and |request|'s <a for=request>mode</a> is either "cors" or "same-origin",
      return "Allowed".
   1. Let |policy| be |policy container|'s <a>integrity policy</a>.
   1. Let |report policy| be |policy container|'s <a>report only integrity policy</a>.
   1. If both |policy| and |report policy| are empty <a>integrity policy struct</a>s, return "Allowed".
-  1. Let |global| be |request|'s <a for=request>client</a>'s <a>global object</a>.
-  1. if |global| is not a <a>Window</a> nor a <a>WorkerGlobalScope</a>, return "Allowed".
+  1. Let |global| be |request|'s <a for=request>client</a>'s <a for="environment settings object">global object</a>.
+  1. If |global| is not a {{Window}} nor a {{WorkerGlobalScope}}, return "Allowed".
   1. Let |block| be a boolean, initially false.
   1. Let |report block| be a boolean, initially false.
-  1. if |policy|'s <a>sources</a> <a for=list>contains</a> "`inline`"
+  1. If |policy|'s <a>sources</a> <a for=list>contains</a> "`inline`"
      and |policy|'s <a>blocked destinations</a> <a for=list>contains</a>
      |request|'s <a for=request>destination</a>,
      set |block| to true.
-  1. if |policy|'s <a>sources</a> <a for=list>contains</a> "`inline`"
+  1. If |policy|'s <a>sources</a> <a for=list>contains</a> "`inline`"
      and |report policy|'s <a>blocked destinations</a> <a for=list>contains</a>
      |request|'s <a for=request>destination</a>,
      set |report block| to true.
@@ -607,14 +593,14 @@ spec:csp3; type:grammar; text:base64-value
   a boolean |report block|, an <a>integrity policy struct</a> |policy|,
   and an <a>integrity policy struct</a> |report policy|, do the following:
 
-  1. Assert that |request|'s <a for=request>client</a> is not null.
+  1. <a>Assert</a>: |request|'s <a for=request>client</a> is not null.
   1. Let |settings object| be |request|'s <a for=request>client</a>.
-  1. Let |global| be |settings object|'s <a>global object</a>.
-  1. Assert that |global| is a <a>Window</a> or a <a>WorkerGlobalScope</a>.
-  1. Let |url| be a <a for=/>URL</a>, initially null.
-  1. If |global| is a <a>Window</a>, set |url| to |global|'s <a>associated Document</a> <a>document URL</a>.
-  1. If |global| is a <a>WorkerGlobalScope</a>, set |url| to |global|'s <a for=WorkerGlobalScope>URL</a>.
-  1. Assert that |url| is a non-null <a for=/>URL</a>.
+  1. Let |global| be |settings object|'s <a for="environment settings object">global object</a>.
+  1. <a>Assert</a>: |global| is a {{Window}} or a {{WorkerGlobalScope}}.
+  1. Let |url| be null.
+  1. If |global| is a {{Window}}, set |url| to |global|'s <a>associated Document</a>'s {{Document/URL}}.
+  1. If |global| is a {{WorkerGlobalScope}}, set |url| to |global|'s <a for=WorkerGlobalScope>URL</a>.
+  1. <a>Assert</a>: |url| a <a for=/>URL</a>.
   1. Let |document URL| be the result of <a>strip URL for use in reports</a> on |url|.
   1. Let |blocked URL| be the result of <a>strip URL for use in reports</a> on |request|'s <a for=request>URL</a>.
   1. If |block|, <a for=list>for each</a> |endpoint| in |policy|'s <a>endpoints</a>:
@@ -658,7 +644,7 @@ spec:csp3; type:grammar; text:base64-value
 
   ### Integration ### {#integration}
 
-  A <a>policy container</a> has extra items:
+  A <a for=/>policy container</a> has extra items:
 
   * <dfn>integrity policy</dfn>, an <a>integrity policy struct</a>.
   * <dfn>report only integrity policy</dfn>, an <a>integrity policy struct</a>.

--- a/index.bs
+++ b/index.bs
@@ -571,16 +571,21 @@ spec:csp3; type:grammar; text:base64-value
   do the following:
 
   1. Let |policy container| be |request|'s <a>policy container</a>.
-  1. if |request|'s <a>integrity metadata</a> is not empty, return "Allowed".
+  1. if |request|'s <a>integrity metadata</a> is not the empty string
+     and |request|'s <a for=request>mode</a> is either "cors" or "same-origin",
+     return "Allowed".
   1. Let |policy| be |policy container|'s <a>integrity policy</a>.
   1. Let |report policy| be |policy container|'s <a>report only integrity policy</a>.
   1. Let |block| be a boolean, initially false.
   1. Let |report block| be a boolean, initially false.
-  1. if |policy|'s <a>enforcement</a> is "block" and |policy|'s <a>source</a> is "inline" and |policy|'s
-     <a>destination</a> is equal to |request|'s <a for=request>destination</a>, set |block| to true.
-  1. if |report policy|'s <a>enforcement</a> is "block" and |report policy|'s <a>source</a> is "inline"
-     and |report policy|'s <a>destination</a> is equal to |request|'s <a for=request>destination</a>, set
-    |report block| to true.
+  1. if |policy|'s <a>enforcement</a> is "block"
+     and |policy|'s <a>source</a> is "inline"
+     and |policy|'s <a>destination</a> is equal to |request|'s <a for=request>destination</a>,
+     set |block| to true.
+  1. if |report policy|'s <a>enforcement</a> is "block"
+     and |report policy|'s <a>source</a> is "inline"
+     and |report policy|'s <a>destination</a> is equal to |request|'s <a for=request>destination</a>,
+     set |report block| to true.
   1. If |block| or |report block|, <a>report violation</a> with |request|, |block|, |report block|,
      |policy| and |report policy|.
   1. If |block|, return "Blocked". Otherwise, return "Allowed".

--- a/index.bs
+++ b/index.bs
@@ -541,14 +541,10 @@ spec:csp3; type:grammar; text:base64-value
   and a <a for=/>policy container</a> |container|, do the following:
 
   1. Let |headers| be |response|'s <a for=response>header list</a>.
-  1. If |headers| <a for="header list">contains</a> a <a>header</a>
-     whose <a>byte-lowercased</a> <a>header name</a>'s <a>isomorphic decode</a>
-     is "`integrity-policy`",
+  1. If |headers| <a for="header list">contains</a> ``integrity-policy``,
      set |container|'s <a>integrity policy</a> be the result of running
      <a>processing an integrity policy</a> with the corresponding <a>header value</a>.
-  1. If |headers| <a for="header list">contains</a> a <a>header</a>
-     whose <a>byte-lowercased</a> <a>header name</a>'s <a>isomorphic decode</a>
-     is "`integrity-policy-report-only`",
+  1. If |headers| <a for="header list">contains</a> ``integrity-policy-report-only``,
      set |container|'s <a>report only integrity policy</a> be the result of running
      <a>processing an integrity policy</a> with the corresponding <a>header value</a>.
   
@@ -606,7 +602,7 @@ spec:csp3; type:grammar; text:base64-value
   1. <a>Assert</a>: |url| is a <a for=/>URL</a>.
   1. Let |documentURL| be the result of <a>strip URL for use in reports</a> on |url|.
   1. Let |blockedURL| be the result of <a>strip URL for use in reports</a> on |request|'s <a for=request>URL</a>.
-  1. If |block|, <a for=list>for each</a> |endpoint| in |policy|'s <a>endpoints</a>:
+  1. If |block| is true, <a for=list>for each</a> |endpoint| in |policy|'s <a>endpoints</a>:
      1. Let |body| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:
                  :   {{IntegrityPolicyViolationReportBody/documentURL}}
                  ::  |documentURL|
@@ -625,7 +621,7 @@ spec:csp3; type:grammar; text:base64-value
               ::  |endpoint|
               :   <var ignore>data</var>
               ::  |body|
-  1. If |reportBlock|, <a for=list>for each</a> |endpoint| in |reportPolicy|'s <a>endpoints</a>:
+  1. If |reportBlock| is true, <a for=list>for each</a> |endpoint| in |reportPolicy|'s <a>endpoints</a>:
      1. Let |reportBody| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:
                  :   {{IntegrityPolicyViolationReportBody/documentURL}}
                  ::  |documentURL|


### PR DESCRIPTION
As discussed, this is replacing #129

It is defining two new headers: `Integrity-Policy` and `Integrity-Policy-Report-Only` that would enable developers to enforce integrity on scripts (in the immediate) and on more request destinations in the future.

# `Integrity-Policy` header

Subresource-Integrity (SRI) enables developers to make sure the assets they intend to load are indeed the assets they are loading. But there's no current way for developers to be sure that all of their scripts are validated using SRI. 

The `Integrity-Policy` header gives developers the ability to assert that every resource of a given type needs to be integrity-checked. If a resource of that type is attempted to be loaded without integrity metadata, that attempt will fail and trigger a violation report.

The `Integrity-Policy` header is a structured field Dictionary, where every member value is an inner list of tokens.
Possible keys are: `blocked-destinations`

## Example usage

A developer that wants to validate that all of their script resources have integrity checks will be able to add a header similar to:
```http
Integrity-Policy: blocked-destinations=(script), endpoints=(integrity-endpoint)
```

From that point, any external script that is fetched without a valid `integrity` attribute (that is, one that translates into non-empty [integrity metadata](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata)) or with a "no-cors" [request mode](https://fetch.spec.whatwg.org/#concept-request-mode), will not be loaded.
It will also trigger a violation [report](https://www.w3.org/TR/reporting-1/).

The header also has a `sources` key. It's only possible value (as well as its default value) is "inline". It's presence would enable future-compatible additions of other integrity sources, such as headers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/pull/133.html" title="Last updated on May 16, 2025, 12:14 PM UTC (6b7e05d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/133/68399a2...6b7e05d.html" title="Last updated on May 16, 2025, 12:14 PM UTC (6b7e05d)">Diff</a>