### PR TITLE
Integrity policy - export the dfns required for integration and fix a bug

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -549,7 +549,7 @@ spec:csp3; type:grammar; text:base64-value
      <a>processing an integrity policy</a> with the corresponding <a>header value</a>.
   
   ### Should request be blocked by Integrity Policy ### {#should-request-be-blocked-by-integrity-policy-section}
-  To determine <dfn>should request be blocked by integrity policy</dfn>, given a <a for=/>request</a> |request|,
+  To determine <dfn export>should request be blocked by integrity policy</dfn>, given a <a for=/>request</a> |request|,
   do the following:
 
   1. Let |policyContainer| be |request|'s <a for=request>policy container</a>.
@@ -567,7 +567,7 @@ spec:csp3; type:grammar; text:base64-value
      and |policy|'s <a>blocked destinations</a> <a for=list>contains</a>
      |request|'s <a for=request>destination</a>,
      set |block| to true.
-  1. If |policy|'s <a>sources</a> <a for=list>contains</a> "`inline`"
+  1. If |reportPolicy|'s <a>sources</a> <a for=list>contains</a> "`inline`"
      and |reportPolicy|'s <a>blocked destinations</a> <a for=list>contains</a>
      |request|'s <a for=request>destination</a>,
      set |reportBlock| to true.

--- a/index.bs
+++ b/index.bs
@@ -514,7 +514,7 @@ spec:csp3; type:grammar; text:base64-value
 
   A <dfn>destination</dfn> is a string. The only possible value for it is "`script`".
 
-  An <dfn>integrity policy struct</dfn>, is a <a>struct</a> that contains the following:
+  An <dfn export>integrity policy struct</dfn>, is a <a>struct</a> that contains the following:
 
     * <dfn>sources</dfn>, a list of <a>source</a>s, initially empty.
     * <dfn>blocked destinations</dfn>, a list of <a>destination</a>s, initially empty.
@@ -537,7 +537,7 @@ spec:csp3; type:grammar; text:base64-value
   1. Return |integrityPolicy|.
   
   ### Parse Integrity-Policy headers ### {#parse-integrity-policy-headers-section}
-  To <dfn>parse Integrity-Policy headers</dfn>, given a <a for=/>Response</a> |response|
+  To <dfn export>parse Integrity-Policy headers</dfn>, given a <a for=/>Response</a> |response|
   and a <a for=/>policy container</a> |container|, do the following:
 
   1. Let |headers| be |response|'s <a for=response>header list</a>.


### PR DESCRIPTION
The "should block request.." & "parse.." algorithms and the integrity policy structs should've been exported. This actually does that so that we can properly integrate with Fetch and HTML.

Beyond that, this also fixes a bug where the reportPolicy's "inline" was ignored.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/pull/134.html" title="Last updated on May 22, 2025, 8:37 AM UTC (0944bc3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/134/a7db551...0944bc3.html" title="Last updated on May 22, 2025, 8:37 AM UTC (0944bc3)">Diff</a>