### PR TITLE
Add blob and data url exemption

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -556,7 +556,7 @@ spec:csp3; type:grammar; text:base64-value
   1. If |parsedMetadata| is not the empty set and
      |request|'s <a for=request>mode</a> is either "`cors`" or "`same-origin`",
      return "Allowed".
-  1. If |request|'s <a for=request>url</a>'s <a for=url>scheme</a> is "data" or "blob",
+  1. If |request|'s <a for=request>url</a> is <a lt="is local">local</a>,
      return "Allowed".
   1. Let |policy| be |policyContainer|'s <a for="policy container">integrity policy</a>.
   1. Let |reportPolicy| be |policyContainer|'s <a>report only integrity policy</a>.

--- a/index.bs
+++ b/index.bs
@@ -560,7 +560,8 @@ spec:csp3; type:grammar; text:base64-value
   1. If |parsedMetadata| is not the empty set and
      |request|'s <a for=request>mode</a> is either "`cors`" or "`same-origin`",
      return "Allowed".
-  1. If |request|'s <a for=request>url</a> is data or blob URL, return "Allowed".
+  1. If |request|'s <a for=request>url</a>'s <a for=url>scheme</a> is "data" or "blob",
+     return "Allowed".
   1. Let |policy| be |policyContainer|'s <a>integrity policy</a>.
   1. Let |reportPolicy| be |policyContainer|'s <a>report only integrity policy</a>.
   1. If both |policy| and |reportPolicy| are empty <a>integrity policy struct</a>s, return "Allowed".

--- a/index.bs
+++ b/index.bs
@@ -560,6 +560,7 @@ spec:csp3; type:grammar; text:base64-value
   1. If |parsedMetadata| is not the empty set and
      |request|'s <a for=request>mode</a> is either "`cors`" or "`same-origin`",
      return "Allowed".
+  1. If |request|'s <a for=request>url</a> is data or blob URL, return "Allowed".
   1. Let |policy| be |policyContainer|'s <a>integrity policy</a>.
   1. Let |reportPolicy| be |policyContainer|'s <a>report only integrity policy</a>.
   1. If both |policy| and |reportPolicy| are empty <a>integrity policy struct</a>s, return "Allowed".


### PR DESCRIPTION
This fixes #136. Both WPT and Chrome's implementation exempt data and blob urls, the spec should probably mention this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/FKLC/webappsec-subresource-integrity/pull/137.html" title="Last updated on Jun 4, 2025, 1:50 PM UTC (b4767bf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/137/2089aeb...FKLC:b4767bf.html" title="Last updated on Jun 4, 2025, 1:50 PM UTC (b4767bf)">Diff</a>