### PR TITLE
[editorial] Make JSON valid

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -719,7 +719,7 @@ spec:csp3; type:grammar; text:base64-value
 
   <div class="example">
   <xmp highlight="json">
-      {'status': 'authenticated', 'username': 'admin'}
+      {"status": "authenticated", "username": "admin"}
   </xmp>
   </div>
 


### PR DESCRIPTION
Single quotes aren't valid JSON. This also happened to make the JSON highlighter freak out and color things in a bizarre fashion.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tabatkins/webappsec-subresource-integrity/pull/139.html" title="Last updated on Jun 3, 2025, 10:17 PM UTC (90510fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/139/2089aeb...tabatkins:90510fb.html" title="Last updated on Jun 3, 2025, 10:17 PM UTC (90510fb)">Diff</a>