### PR TITLE
Fix the report type to match implementations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -580,13 +580,11 @@ spec:csp3; type:grammar; text:base64-value
   ### Report violations ### {#report-violations}
 
   <pre class="idl">
-    [Exposed=Window]
-    interface IntegrityViolationReportBody : ReportBody {
-      [Default] object toJSON();
-      readonly attribute USVString documentURL;
-      readonly attribute USVString blockedURL;
-      readonly attribute USVString destination;
-      readonly attribute boolean   reportOnly;
+    dictionary IntegrityViolationReportBody : ReportBody {
+      USVString documentURL;
+      USVString blockedURL;
+      USVString destination;
+      boolean   reportOnly;
     };
   </pre>
 
@@ -605,14 +603,14 @@ spec:csp3; type:grammar; text:base64-value
   1. Let |documentURL| be the result of <a>strip URL for use in reports</a> on |url|.
   1. Let |blockedURL| be the result of <a>strip URL for use in reports</a> on |request|'s <a for=request>URL</a>.
   1. If |block| is true, <a for=list>for each</a> |endpoint| in |policy|'s <a>endpoints</a>:
-     1. Let |body| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:
-                 :   {{IntegrityPolicyViolationReportBody/documentURL}}
+     1. Let |body| be a new {{IntegrityViolationReportBody}}, initialized as follows:
+                 :   {{IntegrityViolationReportBody/documentURL}}
                  ::  |documentURL|
-                 :   {{IntegrityPolicyViolationReportBody/blockedURL}}
+                 :   {{IntegrityViolationReportBody/blockedURL}}
                  ::  |blockedURL|
-                 :   {{IntegrityPolicyViolationReportBody/destination}}
+                 :   {{IntegrityViolationReportBody/destination}}
                  ::  |request|'s <a for=request>destination</a>
-                 :   {{IntegrityPolicyViolationReportBody/reportOnly}}
+                 :   {{IntegrityViolationReportBody/reportOnly}}
                  ::  false
      2. <a>Generate and queue a report</a> with the following arguments:
               :   <a for="generate and queue a report"><i>context</i></a>
@@ -624,14 +622,14 @@ spec:csp3; type:grammar; text:base64-value
               :   <a for="generate and queue a report"><i>data</i></a>
               ::  |body|
   1. If |reportBlock| is true, <a for=list>for each</a> |endpoint| in |reportPolicy|'s <a>endpoints</a>:
-     1. Let |reportBody| be a new {{IntegrityPolicyViolationReportBody}}, initialized as follows:
-                 :   {{IntegrityPolicyViolationReportBody/documentURL}}
+     1. Let |reportBody| be a new {{IntegrityViolationReportBody}}, initialized as follows:
+                 :   {{IntegrityViolationReportBody/documentURL}}
                  ::  |documentURL|
-                 :   {{IntegrityPolicyViolationReportBody/blockedURL}}
+                 :   {{IntegrityViolationReportBody/blockedURL}}
                  ::  |blockedURL|
-                 :   {{IntegrityPolicyViolationReportBody/destination}}
+                 :   {{IntegrityViolationReportBody/destination}}
                  ::  |request|'s <a for=request>destination</a>
-                 :   {{IntegrityPolicyViolationReportBody/reportOnly}}
+                 :   {{IntegrityViolationReportBody/reportOnly}}
                  ::  true 
      2. <a>Generate and queue a report</a> with the following arguments:
               :   <a for="generate and queue a report"><i>context</i></a>


### PR DESCRIPTION
The Integrity-Policy report type was specified as "integrity-policy-violation", but was [tested as "integrity-violation"](https://github.com/web-platform-tests/wpt/blob/ce5b64e143a0f082f9ca9989d78a01ea69586fe8/subresource-integrity/integrity-policy/script.https.html#L20).
As a result implementations implement the (shorter and sufficiently expressive) "integrity-violation".

This PR aligns the spec on that type.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/pull/141.html" title="Last updated on Jun 11, 2025, 6:18 AM UTC (2e0ad44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/141/2e039a4...2e0ad44.html" title="Last updated on Jun 11, 2025, 6:18 AM UTC (2e0ad44)">Diff</a>