### PR TITLE
Integrity policy example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -533,6 +533,19 @@ spec:csp3; type:grammar; text:base64-value
   1. If |dictionary|["`endpoints`"] <a for=map>exists</a>:
     1. Set |integrityPolicy|'s <a>endpoints</a> to |dictionary|['endpoints'].
   1. Return |integrityPolicy|.
+
+  <div class=example>
+  The following header will cause the request for any external script that's loaded without integrity
+  metadata (or any no-CORS external script) to be blocked.
+  ```http
+    Integrity-Policy: blocked-destinations=(script), endpoints=(integrity-endpoint)
+  ```
+  The blocking will also trigger a report to the "`integrity-endpoint`"
+  reporting endpoint (defined by the relevant `Reporting-Endpoints` header).
+  
+  Developers can also register a ReportingObserver for "`integrity-violation`" to get reports in 
+  
+  </div>
   
   ### Parse Integrity-Policy headers ### {#parse-integrity-policy-headers-section}
   To <dfn export>parse Integrity-Policy headers</dfn>, given a <a for=/>Response</a> |response|

--- a/index.bs
+++ b/index.bs
@@ -535,8 +535,8 @@ spec:csp3; type:grammar; text:base64-value
   1. Return |integrityPolicy|.
 
   <div class=example>
-  The following header will cause the request for any external script that's loaded without integrity
-  metadata (or any no-CORS external script) to be blocked.
+  The following header block the request for any external script that's loaded without integrity
+  metadata (or any no-CORS external script).
   ```http
     Integrity-Policy: blocked-destinations=(script), endpoints=(integrity-endpoint)
   ```

--- a/index.bs
+++ b/index.bs
@@ -543,8 +543,8 @@ spec:csp3; type:grammar; text:base64-value
   The blocking will also trigger a report to the "`integrity-endpoint`"
   reporting endpoint (defined by the relevant `Reporting-Endpoints` header).
   
-  Developers can also register a ReportingObserver for "`integrity-violation`" to get reports in 
-  
+  Developers can also register a ReportingObserver for "`integrity-violation`" to get JavaScript-based
+  reports.
   </div>
   
   ### Parse Integrity-Policy headers ### {#parse-integrity-policy-headers-section}


### PR DESCRIPTION
Addresses the comment on https://github.com/w3c/webappsec-subresource-integrity/pull/133#issuecomment-2951224941 by adding a usage example and a minimal explanation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/pull/142.html" title="Last updated on Jun 12, 2025, 2:41 PM UTC (5f4a4a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/142/2e039a4...5f4a4a2.html" title="Last updated on Jun 12, 2025, 2:41 PM UTC (5f4a4a2)">Diff</a>