### PR TITLE
fix: initialize strongest with null

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -372,7 +372,7 @@ spec:csp3; type:grammar; text:base64-value
 
   ### Get the strongest metadata from |set| ### {#get-the-strongest-metadata}
 
-  1.  Let |result| be the empty set and |strongest| be empty.
+  1.  Let |result| be the empty set and |strongest| be null.
   2.  For each |item| in |set|:
       1.  Assert: |item|["`alg`"] is a [=valid SRI hash algorithm token=].
       2.  If |result| is the empty set, then:
@@ -387,7 +387,7 @@ spec:csp3; type:grammar; text:base64-value
       6.  Otherwise, if |newAlgorithmIndex| is greater than |currentAlgorithmIndex|:
           1.  Set |strongest| to |item|.
           2.  Set |result| to « |item| ».
-      7.  Otherwise, if |newAlgorithmIndex| and |currentAlgorithmIndex| are the
+      7.  Otherwise, |newAlgorithmIndex| and |currentAlgorithmIndex| are the
           same value. [=set/Append=] |item| to |result|.
   3.  Return |result|.
 


### PR DESCRIPTION
While implementing the latest draft to undici, https://github.com/nodejs/undici/pull/4307, I found following issues:

Why is strongest initialized with an empty string, just to later contain an object? Why cant we just initialize it with null?

I think the word `if` was missing in `Otherwise, |newAlgorithmIndex| and |currentAlgorithmIndex| are the`

The point is, that we search for the strongest hash methods and the corresponding hashes. Without the `if` we get also based on the input we keep also weaker hashes, just based on the order of the input for the integrity string.

WIthout the if the second test would fail, just because the order is different.

```js
  test('should return strongest sha512 /1', () => {
    const result = getStrongestMetadata([
      { alg: 'sha256', val: 'sha256-abc' },
      { alg: 'sha384', val: 'sha384-def' },
      { alg: 'sha512', val: 'sha512-ghi' }
    ])
    assert.deepEqual(result, [
      { alg: 'sha512', val: 'sha512-ghi' }
    ])
  })

  test('should return strongest sha512 /2', () => {
    const result = getStrongestMetadata([
      { alg: 'sha512', val: 'sha512-ghi' },
      { alg: 'sha256', val: 'sha256-abc' },
      { alg: 'sha384', val: 'sha384-def' }
    ])
    assert.deepEqual(result, [
      { alg: 'sha512', val: 'sha512-ghi' }
    ])
  })
```

Also


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Uzlopak/webappsec-subresource-integrity/pull/145.html" title="Last updated on Jun 30, 2025, 10:54 AM UTC (faa726d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/145/ab68b58...Uzlopak:faa726d.html" title="Last updated on Jun 30, 2025, 10:54 AM UTC (faa726d)">Diff</a>