### PR TITLE
Extend integrity policy's coverage to include stylesheets

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -525,6 +525,8 @@ spec:csp3; type:grammar; text:base64-value
   1. If |dictionary|["`blocked-destinations`"] <a for=list>exists</a>:
     1. If its value <a for=list>contains</a> "`script`",
        <a for=list>append</a> "`script`" to |integrityPolicy|'s <a>blocked destinations</a>.
+    1. If its value <a for=list>contains</a> "`style`",
+       <a for=list>append</a> "`style`" to |integrityPolicy|'s <a>blocked destinations</a>.
   1. If |dictionary|["`endpoints`"] <a for=map>exists</a>:
     1. Set |integrityPolicy|'s <a>endpoints</a> to |dictionary|['endpoints'].
   1. Return |integrityPolicy|.


### PR DESCRIPTION
Hello!

As a next step to integrity policy, we are thinking about supporting stylesheets too. So, I'm creating this pull request to add it to the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/FKLC/webappsec-subresource-integrity/pull/146.html" title="Last updated on Jul 4, 2025, 1:18 PM UTC (87e2e96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/146/679d685...FKLC:87e2e96.html" title="Last updated on Jul 4, 2025, 1:18 PM UTC (87e2e96)">Diff</a>