### PR TITLE
parseMetadata: first check algorithm validity

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -355,10 +355,10 @@ spec:csp3; type:grammar; text:base64-value
       4.  Let |algorithm-and-value| be the result of
           <a lt="strictly split">splitting</a> |algorithm-expression| on U+002D (-).
       5.  Let |algorithm| be |algorithm-and-value|[0].
-      6.  If |algorithm-and-value|[1] <a for=list>exists</a>, set
-          |base64-value| to |algorithm-and-value|[1].
-      7.  If |algorithm| is not a [=valid SRI hash algorithm token=], then
+      6.  If |algorithm| is not a [=valid SRI hash algorithm token=], then
           [=iteration/continue=].
+      7.  If |algorithm-and-value|[1] <a for=list>exists</a>, set
+          |base64-value| to |algorithm-and-value|[1].
       8.  Let |metadata| be the ordered map  «["alg" → |algorithm|,
           "val" → |base64-value|]».
 


### PR DESCRIPTION
We should first check if the algorithm is valid, before allocating memory for the base64 encoded value.