### PR TITLE
Add issue & pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-new-issue.yml
+++ b/.github/ISSUE_TEMPLATE/0-new-issue.yml
@@ -1,0 +1,15 @@
+name: New issue
+description: File a new issue against the Subresource Integrity standard.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filling out this form, please take a look at the [W3C Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc/) and our [contributing guidelines](https://github.com/w3c/webappsec-subresource-integrity/blob/main/CONTRIBUTING.md).
+  - type: textarea
+    attributes:
+      label: "What is the issue with Subresource Integrity?"
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: "Thank you for contributing to SRI!"

--- a/.github/ISSUE_TEMPLATE/1-new-feature.yml
+++ b/.github/ISSUE_TEMPLATE/1-new-feature.yml
@@ -1,0 +1,25 @@
+name: New feature
+description: Request a new feature in the HTML Standard.
+labels: ["feature-request", "needs implementer interest"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filling out this form, please take a look at the [W3C Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc/) and our [contributing guidelines](https://github.com/w3c/webappsec-subresource-integrity/blob/main/CONTRIBUTING.md).
+  - type: textarea
+    attributes:
+      label: "What problem are you trying to solve?"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "What solutions exist today?"
+  - type: textarea
+    attributes:
+      label: "How would you solve it?"
+  - type: textarea
+    attributes:
+      label: "Anything else?"
+  - type: markdown
+    attributes:
+      value: "Thank you for contributing to SRI!"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!--
+Thank you for contributing to the Subresource Integrity. Please describe the change you are making and complete the checklist below if your change is not editorial.
+
+When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.
+
+If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
+-->
+
+- [ ] At least two implementers are interested (and none opposed):
+   * …
+   * …
+- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
+   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
+- [ ] Implementation bugs are filed:
+   * Chromium: …
+   * Gecko: …
+   * WebKit: …
+<!--
+Here are links to the relevant bug trackers
+* Chrome: https://crbug.com/new
+* Firefox: https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=DOM%3A%20Security
+* WebKit: https://bugs.webkit.org/enter_bug.cgi
+-->
+
+>
+- [ ] MDN issue is filed: …
+<!--
+Use https://github.com/mdn/content/issues/new/choose to file an issue
+with MDN and feel free to remove this comment
+ -->
+
+(See our [contributing guidelines](https://github.com/w3c/webappsec-subresource-integrity/blob/main/CONTRIBUTING.md) for more details.)


### PR DESCRIPTION
I allowed myself to adapt the wonderful issue & pull request templates from WHATWG, such that we can have pointers to all the interesting things (implementation bugs, wpt, standards positions etc). I believe this will help transition SRI to a living standard.
