### PR TITLE
avoid strict splitting in parseMetada to allow base64url

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -353,7 +353,7 @@ spec:csp3; type:grammar; text:base64-value
       2.  Let |algorithm-expression| be |expression-and-options|[0].
       3.  Let |base64-value| be the empty string.
       4.  Let |algorithm-and-value| be the result of
-          <a lt="strictly split">splitting</a> |algorithm-expression| on U+002D (-).
+          splitting |algorithm-expression| on the first occurence of U+002D (-).
       5.  Let |algorithm| be |algorithm-and-value|[0].
       6.  If |algorithm-and-value|[1] <a for=list>exists</a>, set
           |base64-value| to |algorithm-and-value|[1].


### PR DESCRIPTION
We should do a strict split of the algorithm-expression, but only split it on the first occurence of the dash character.

base64urls` uses the dash character too, so if we want to allow base64url we cant do strict splitting.