### PR TITLE
reduce complexity of get strongest metadata

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -373,11 +373,10 @@ spec:csp3; type:grammar; text:base64-value
   ### Get the strongest metadata from |set| ### {#get-the-strongest-metadata}
 
   1.  Let |result| be the empty set.
-  2.  If |set| [=set/is empty=] set, return |result|.
-  3   Let |currentAlgorithmIndex| be null.
-  4.  For each |item| in |set|:
+  2.  Let |currentAlgorithmIndex| be null.
+  3.  For each |item| in |set|:
       1.  Assert: |item|["`alg`"] is a [=valid SRI hash algorithm token=].
-      2.  If |result| is the empty set, then:
+      2.  If |currentAlgorithmIndex| is null, then:
           1. [=set/Append=] |item| to |result|.
           2. Set |currentAlgorithmIndex| to be the index of |item|["`alg`"]
              in the [=valid SRI hash algorithm token set=].
@@ -390,9 +389,9 @@ spec:csp3; type:grammar; text:base64-value
           2.  Set |result| to « |item| ».
       6.  Otherwise, |newAlgorithmIndex| and |currentAlgorithmIndex| are the
           same value. [=set/Append=] |item| to |result|.
-  5.  Return |result|.
+  4.  Return |result|.
 
-  Note: step 4.1. is optional when |set| is the result of <a>parse metadata</a>.
+  Note: step 3.1. is optional when |set| is the result of <a>parse metadata</a>.
 
 <h4 dfn export id=does-response-match-metadatalist>Do |bytes| match |metadataList|?</h4>
 


### PR DESCRIPTION
I want to bring this to the discussion. Instead of storing a struct and calling indexOf over and over, we keep it "simpler". 

I know, i know... this is a highly opinionated suggestion.

Also the step 4.1 seems to be redundant. I assume that all implementations will parse the metadata and pass it directly to `getStrongestMetadata()`, to filter the relevant metadata. So we dont need to actually assert again if the solution does not allow to pass arbitrary data to getStrongestMetadata.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Uzlopak/webappsec-subresource-integrity/pull/151.html" title="Last updated on Jul 9, 2025, 2:48 PM UTC (befb2bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/151/9f92d34...Uzlopak:befb2bb.html" title="Last updated on Jul 9, 2025, 2:48 PM UTC (befb2bb)">Diff</a>