### PR TITLE
[Editorial] Export the parse-metadata algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -340,7 +340,8 @@ spec:csp3; type:grammar; text:base64-value
 
   ### Parse metadata ### {#parse-metadata-section}
 
-  When asked to <dfn>parse metadata</dfn> given a string |metadata|, run the following steps:
+  When asked to <dfn export>parse metadata</dfn> given a string |metadata|, run the
+  following steps:
 
   Note: the algorithm returns a set of hash expressions whose hash functions are understood
   by the user agent.


### PR DESCRIPTION
The "parse metadata" algorithm is references by Content Security Policy. It used to be exported, but that changed with https://github.com/w3c/webappsec-subresource-integrity/pull/135 (probably inadvertently).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/pull/152.html" title="Last updated on Jul 10, 2025, 6:25 AM UTC (fd1f153)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/152/38603d6...fd1f153.html" title="Last updated on Jul 10, 2025, 6:25 AM UTC (fd1f153)">Diff</a>