### PR TITLE
feat: better bytesMatch  algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -399,15 +399,15 @@ spec:csp3; type:grammar; text:base64-value
   2.  If |parsedMetadata| [=set/is empty=] set, return `true`.
   3.  Let |metadata| be the result of <a href="#get-the-strongest-metadata">
       getting the strongest metadata from |parsedMetadata|</a>.
-  4.  For each |item| in |metadata|:
-      1.  Let |algorithm| be the |item|["alg"].
-      2.  Let |expectedValue| be the |item|["val"].
-      3.  Let |actualValue| be the result of <a
-          href="#apply-algorithm-to-response">applying |algorithm| to |bytes|
-          </a>.
-      4.  If |actualValue| is a case-sensitive match for
-          |expectedValue|, return `true`.
-  5.  Return `false`.
+  4.  Let |algorithm| be the first element of |item|["alg"].
+  5.  Let |actualValue| be the result of <a
+      href="#apply-algorithm-to-response">applying |algorithm| to |bytes|
+      </a>.
+  6.  For each |item| in |metadata|:
+      1.  Let |expectedValue| be the |item|["val"].
+      2.  If |expectedValue| is a case-sensitive match for
+          |actualValue|, return `true`.
+  7.  Return `false`.
 
   This algorithm allows the user agent to accept multiple, valid strong hash
   functions. For example, a developer might write a `script` element such as:


### PR DESCRIPTION
The algorithm for matching the hashes is only performant if you have one hash provided. 

Lets say for some reason you provide five sha512 hashes for the resource. Than algorithm of the spec suggests, that we should hash 5 times the bytes to get five times the same actualValue, just to compare the actualValue with the expectedValue. This is obviously imperformant and repetetive.

We just need to hash the bytes only once to get the actualValue and then only compare with the expectedValue.


<!--
Thank you for contributing to the Subresource Integrity. Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] Implementation bugs are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
<!--
Here are links to the relevant bug trackers
* Chrome: https://crbug.com/new
* Firefox: https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=DOM%3A%20Security
* WebKit: https://bugs.webkit.org/enter_bug.cgi
-->

>
- [ ] MDN issue is filed: …
<!--
Use https://github.com/mdn/content/issues/new/choose to file an issue
with MDN and feel free to remove this comment
 -->

(See our [contributing guidelines](https://github.com/w3c/webappsec-subresource-integrity/blob/main/CONTRIBUTING.md) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Uzlopak/webappsec-subresource-integrity/pull/153.html" title="Last updated on Aug 12, 2025, 9:45 PM UTC (4d63596)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-subresource-integrity/153/f7029a4...Uzlopak:4d63596.html" title="Last updated on Aug 12, 2025, 9:45 PM UTC (4d63596)">Diff</a>