### PR TITLE
Makefile: Replace CSSWG-API-specific force=1 with die-on=nothing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ index.kramdown.html: spec_v1.markdown template.erb
 	sed -e 's/\[\[/\\[\\[/g' -e 's/\]\]/\\]\\]/g' ./spec_v1.markdown | kramdown --parse-block-html --template='template.erb' > index.kramdown.html
 
 index.html: index.bs
-	curl https://www.w3.org/publications/spec-generator/ -F file=@index.bs -F force=1 -F type=bikeshed-spec -F output=html --fail -o index.html
+	curl https://www.w3.org/publications/spec-generator/ -F file=@index.bs -F die-on=nothing -F type=bikeshed-spec -F output=html --fail -o index.html
 
 local:
 	bikeshed -f spec index.bs


### PR DESCRIPTION
This is a follow-up to #168. spec-generator does not recognize `force=1`; it is equivalent to `die-on=nothing`.